### PR TITLE
Added match reporting

### DIFF
--- a/bin/SQL updates/2016-03-15 - match reports.sql
+++ b/bin/SQL updates/2016-03-15 - match reports.sql
@@ -1,0 +1,35 @@
+USE `toptable`;
+CREATE TABLE IF NOT EXISTS `team_match_reports` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `home_team` int(11) unsigned NOT NULL,
+  `away_team` int(11) unsigned NOT NULL,
+  `scheduled_date` date NOT NULL,
+  `published` datetime DEFAULT NULL,
+  `author` int(11) unsigned NOT NULL,
+  `report` longtext,
+  PRIMARY KEY (`id`),
+  KEY `team_match_report` (`home_team`,`away_team`,`scheduled_date`),
+  CONSTRAINT `team_match_report` FOREIGN KEY (`home_team`, `away_team`, `scheduled_date`) REFERENCES `team_matches` (`home_team`, `away_team`, `scheduled_date`),
+  CONSTRAINT `team_match_report_author` FOREIGN KEY (`author`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
+
+
+ALTER TABLE `team_matches`
+	DROP COLUMN `report`;
+
+ALTER TABLE `roles`
+	ADD COLUMN `match_report_create` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'If 1 the person can create match reports for any team.' AFTER `match_cancel`,
+	ADD COLUMN `match_report_create_associated` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'If 1 the person can create match reports involving teams the user is associated with (by playing for or captaining the team or being secretary for the club)' AFTER `match_report_create`,
+	ADD COLUMN `match_report_edit_own` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `match_report_create_team`,
+	ADD COLUMN `match_report_edit_all` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `match_report_edit_own`,
+	ADD COLUMN `match_report_delete_own` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `match_report_edit_all`,
+	ADD COLUMN `match_report_delete_all` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `match_report_delete_own`;
+
+UPDATE `toptable`.`roles` SET `match_report_create`='1', `match_report_create_associated`='1', `match_report_edit_own`='1', `match_report_edit_all`='1', `match_report_delete_own`='1', `match_report_delete_all`='1' WHERE  `id`IN (1, 2);
+
+INSERT INTO `toptable`.`system_event_log_types`
+(`object_type`, `event_type`, `object_description`, `description`, `view_action_for_uri`, `plural_objects`, `public_event`)
+VALUES
+('team-match', 'report-create', 'Team Matches', 'system-event-log.description.report-create', '/matches/team/view_by_ids', 'matches', '1'),
+('team-match', 'report-edit', 'Team Matches', 'system-event-log.description.report-edit', '/matches/team/view_by_ids', 'matches', '1');
+

--- a/bin/tests/browser-tests.pl
+++ b/bin/tests/browser-tests.pl
@@ -1,0 +1,12 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use HTTP::BrowserDetect;
+
+my $ua1 = HTTP::BrowserDetect->new( "Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" );
+my $ua2 = HTTP::BrowserDetect->new( "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" );
+
+printf "User agent 1 robot: %s\n", $ua1->browser_string;
+printf "User agent 2 robot: %s\n", $ua2->browser_string;
+

--- a/bin/tests/test-captain.pl
+++ b/bin/tests/test-captain.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use DateTime;
+use DateTime::TimeZone;
+use Try::Tiny;
+use FindBin qw( $Bin );
+use lib "$Bin/../../lib";
+use Data::Dumper;
+use TopTable::Schema;
+use Data::Dumper;
+use Time::HiRes qw( gettimeofday tv_interval );
+
+my $schema  = TopTable::Schema->connect("dbi:mysql:toptable", "toptable", "toptable");
+my $season  = $schema->resultset("Season")->find( 1 );
+my $team    = $schema->resultset("Team")->find( 1 );
+
+my $captain = $team->get_captain({season => $season});
+
+printf "%s\n", $captain->display_name;

--- a/lib/TopTable.pm
+++ b/lib/TopTable.pm
@@ -148,12 +148,10 @@ sub build_message {
       $text = javascript_value_escape( $text ) if defined( $c->request->headers->header("X-Requested-With") ) and $c->request->headers->header("X-Requested-With") eq "XMLHttpRequest";
       return $text;
     } else {
-      # Not a hashref, just do a 'maketext' on the value
-      my $text = $c->maketext( $message );
-      
+      # Not a hashref, just return the value
       # Escape javascript if necessary
-      $text = javascript_value_escape( $text ) if defined( $c->request->headers->header("X-Requested-With") ) and $c->request->headers->header("X-Requested-With") eq "XMLHttpRequest";
-      return $text;
+      $message = javascript_value_escape( $message ) if defined( $c->request->headers->header("X-Requested-With") ) and $c->request->headers->header("X-Requested-With") eq "XMLHttpRequest";
+      return $message;
     }
   }
   
@@ -172,12 +170,10 @@ sub build_message {
       $return_message .= sprintf( "  <li>%s</li>", $text );
     } else {
       # Not a hashref, just do a 'maketext' on the value
-      my $text = $c->maketext( $message );
-      
       # Escape javascript if necessary
-      $text = javascript_value_escape( $text ) if $c->request->headers->header("X-Requested-With") eq "XMLHttpRequest";
+      $message = javascript_value_escape( $message ) if $c->request->headers->header("X-Requested-With") eq "XMLHttpRequest";
       
-      $return_message .= sprintf( "  <li>%s</li>", $text );
+      $return_message .= sprintf( "  <li>%s</li>", $message );
     }
   }
   

--- a/lib/TopTable/Controller/News.pm
+++ b/lib/TopTable/Controller/News.pm
@@ -336,7 +336,7 @@ sub edit :Private {
   my $current_details = $article->current_details;
   
   # Check that we are authorised to edit this article
-  my $redirect_on_fail = 1 if !$c->user_exists;
+  my $redirect_on_fail = 1 if !$c->user_exists or ( $c->user_exists and $c->user->id != $article->updated_by_user->id );
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["news_article_edit_all", $c->maketext("user.auth.edit-news"), $redirect_on_fail] );
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["news_article_edit_own", $c->maketext("user.auth.edit-news"), 1] ) if !$c->stash->{authorisation}{news_article_edit_all} and $c->user_exists and $c->user->id == $article->updated_by_user->id;
   
@@ -396,7 +396,7 @@ sub delete :Private {
   
   # Check that we are authorised to delete this article
   # The second check (if we get to it) does not redirect, as we don't know the original creator of this article yet (or if the article even exists)
-  my $redirect_on_fail = 1 unless $c->user_exists;
+  my $redirect_on_fail = 1 if !$c->user_exists or ( $c->user_exists and $c->user->id != $article->updated_by_user->id );
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["news_article_delete_all", $c->maketext("user.auth.delete-news"), $redirect_on_fail] );
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["news_article_delete_own", $c->maketext("user.auth.delete-news"), 1] ) if !$c->stash->{authorisation}{news_article_edit_all} and $c->user_exists;
   

--- a/lib/TopTable/Controller/Root.pm
+++ b/lib/TopTable/Controller/Root.pm
@@ -53,12 +53,6 @@ Routines to run on every page load.
 sub begin :Private {
   my ( $self, $c ) = @_;
   
-  # Disable SSL if in debug mode
-  if ( $c->debug ) {
-    $c->config->{require_ssl}{disabled}       = 1;
-    $c->config->{require_ssl}{ignore_on_post} = 1;
-  }
-  
   # Select the language if we have one - if not, the request headers sent by the browser will be used instead
   # Ensure dashes are replaced with underscores
   my $language = $c->get_locale_with_uri;

--- a/lib/TopTable/Controller/Teams.pm
+++ b/lib/TopTable/Controller/Teams.pm
@@ -491,7 +491,7 @@ sub view_finalise :Private {
       $c->uri_for("/static/css/responsive-tabs/responsive-tabs.css"),
       $c->uri_for("/static/css/responsive-tabs/style-jqueryui.css"),
     ],
-    view_online_display => sprintf( "Viewing %s %s", $encoded_name ),
+    view_online_display => sprintf( "Viewing %s", $encoded_name ),
     view_online_link    => 1,
     no_filter           => 1, # Don't include the averages filter form on a team averages view
     matches             => $matches,

--- a/lib/TopTable/Schema/Result/Person.pm
+++ b/lib/TopTable/Schema/Result/Person.pm
@@ -688,8 +688,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-01-08 16:54:51
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:/zZ/bIljpo18UkEaEHqulA
+# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-03-21 21:51:46
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:dMz4v08d1MvpmEX2IjAl3g
 
 #
 # Row-level helper methods
@@ -854,6 +854,72 @@ sub games_played_in_season {
       -asc    => [ qw( team_match.scheduled_date me.actual_game_number ) ],
     },
   });
+}
+
+=head2 plays_for
+
+Returns true if the person plays for the specified team in the specified season.
+
+=cut
+
+sub plays_for {
+  my ( $self, $parameters ) = @_;
+  my $team    = $parameters->{team};
+  my $season  = $parameters->{season};
+  
+  my @players = $team->get_players({season => $season});
+  
+  # Start off with a default of false
+  my $plays_for = 0;
+  
+  # Loop through the players trying to find the person ID
+  foreach my $player ( @players ) {
+    if ( $player->person->id == $self->id ) {
+      # IDs match, set plays for to true
+      $plays_for = 1;
+      
+      # Exit the loop
+      last;
+    }
+  }
+  
+  return $plays_for;
+}
+
+=head2 captain_for
+
+Returns true if the person is captain for the specified team in the specified season.
+
+=cut
+
+sub captain_for {
+  my ( $self, $parameters ) = @_;
+  my $team    = $parameters->{team};
+  my $season  = $parameters->{season};
+  
+  # Get the team's captain
+  my $captain = $team->get_captain({season => $season});
+  $captain = $captain->id if defined( $captain );
+  
+  # Return true if the IDs match or false if not
+  return ( defined( $captain ) and $captain == $self->id ) ? 1 : 0;
+}
+
+=head2 secretary_for
+
+Returns true if the person is secretary for the specified club.
+
+=cut
+
+sub secretary_for {
+  my ( $self, $parameters ) = @_;
+  my $club = $parameters->{club};
+  
+  # Get the club's secretary
+  my $secretary = $club->secretary->id if defined( $club->secretary );
+  
+  # Return true if the IDs match or false if not
+  return ( defined( $secretary ) and $secretary == $self->id ) ? 1 : 0;
 }
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/TopTable/Schema/Result/Role.pm
+++ b/lib/TopTable/Schema/Result/Role.pm
@@ -306,6 +306,52 @@ __PACKAGE__->table("roles");
   extra: {unsigned => 1}
   is_nullable: 0
 
+=head2 match_report_create
+
+  data_type: 'tinyint'
+  default_value: 0
+  extra: {unsigned => 1}
+  is_nullable: 0
+
+If 1 the person can create match reports for any team.
+
+=head2 match_report_create_associated
+
+  data_type: 'tinyint'
+  default_value: 0
+  extra: {unsigned => 1}
+  is_nullable: 0
+
+If 1 the person can create match reports involving teams the user is associated with (by playing for or captaining the team or being secretary for the club)
+
+=head2 match_report_edit_own
+
+  data_type: 'tinyint'
+  default_value: 0
+  extra: {unsigned => 1}
+  is_nullable: 0
+
+=head2 match_report_edit_all
+
+  data_type: 'tinyint'
+  default_value: 0
+  extra: {unsigned => 1}
+  is_nullable: 0
+
+=head2 match_report_delete_own
+
+  data_type: 'tinyint'
+  default_value: 0
+  extra: {unsigned => 1}
+  is_nullable: 0
+
+=head2 match_report_delete_all
+
+  data_type: 'tinyint'
+  default_value: 0
+  extra: {unsigned => 1}
+  is_nullable: 0
+
 =head2 meeting_view
 
   data_type: 'tinyint'
@@ -964,6 +1010,48 @@ __PACKAGE__->add_columns(
     extra => { unsigned => 1 },
     is_nullable => 0,
   },
+  "match_report_create",
+  {
+    data_type => "tinyint",
+    default_value => 0,
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "match_report_create_associated",
+  {
+    data_type => "tinyint",
+    default_value => 0,
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "match_report_edit_own",
+  {
+    data_type => "tinyint",
+    default_value => 0,
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "match_report_edit_all",
+  {
+    data_type => "tinyint",
+    default_value => 0,
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "match_report_delete_own",
+  {
+    data_type => "tinyint",
+    default_value => 0,
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "match_report_delete_all",
+  {
+    data_type => "tinyint",
+    default_value => 0,
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
   "meeting_view",
   {
     data_type => "tinyint",
@@ -1419,8 +1507,8 @@ Composing rels: L</user_roles> -> user
 __PACKAGE__->many_to_many("users", "user_roles", "user");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-02-02 09:27:06
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ggi6exxqYs6ISbwyxunImQ
+# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-03-16 00:35:41
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:S4uZXOsue50wuf6B340Hiw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/TopTable/Schema/Result/Team.pm
+++ b/lib/TopTable/Schema/Result/Team.pm
@@ -361,6 +361,24 @@ sub get_players {
   });
 }
 
+=head2 get_captain
+
+Retrieve the captain registered for this team for the given season.
+
+=cut
+
+sub get_captain {
+  my ( $self, $parameters ) = @_;
+  my $season = $parameters->{season};
+  
+  return $self->search_related("team_seasons", {
+    season => $season->id,
+  }, {
+    prefetch => "captain",
+    rows => 1, 
+  })->single->captain;
+}
+
 =head2 get_season
 
 Retrieve details for the specified season for this team.

--- a/lib/TopTable/Schema/Result/TeamMatchReport.pm
+++ b/lib/TopTable/Schema/Result/TeamMatchReport.pm
@@ -1,0 +1,201 @@
+use utf8;
+package TopTable::Schema::Result::TeamMatchReport;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+TopTable::Schema::Result::TeamMatchReport
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=item * L<DBIx::Class::PassphraseColumn>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
+
+=head1 TABLE: C<team_match_reports>
+
+=cut
+
+__PACKAGE__->table("team_match_reports");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_auto_increment: 1
+  is_nullable: 0
+
+=head2 home_team
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 away_team
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 scheduled_date
+
+  data_type: 'date'
+  datetime_undef_if_invalid: 1
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 published
+
+  data_type: 'datetime'
+  datetime_undef_if_invalid: 1
+  is_nullable: 1
+
+=head2 author
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 report
+
+  data_type: 'longtext'
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_auto_increment => 1,
+    is_nullable => 0,
+  },
+  "home_team",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_foreign_key => 1,
+    is_nullable => 0,
+  },
+  "away_team",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_foreign_key => 1,
+    is_nullable => 0,
+  },
+  "scheduled_date",
+  {
+    data_type => "date",
+    datetime_undef_if_invalid => 1,
+    is_foreign_key => 1,
+    is_nullable => 0,
+  },
+  "published",
+  {
+    data_type => "datetime",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 1,
+  },
+  "author",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_foreign_key => 1,
+    is_nullable => 0,
+  },
+  "report",
+  { data_type => "longtext", is_nullable => 1 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+=head1 RELATIONS
+
+=head2 author
+
+Type: belongs_to
+
+Related object: L<TopTable::Schema::Result::User>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "author",
+  "TopTable::Schema::Result::User",
+  { id => "author" },
+  { is_deferrable => 1, on_delete => "RESTRICT", on_update => "RESTRICT" },
+);
+
+=head2 team_match
+
+Type: belongs_to
+
+Related object: L<TopTable::Schema::Result::TeamMatch>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "team_match",
+  "TopTable::Schema::Result::TeamMatch",
+  {
+    away_team      => "away_team",
+    home_team      => "home_team",
+    scheduled_date => "scheduled_date",
+  },
+  { is_deferrable => 1, on_delete => "RESTRICT", on_update => "RESTRICT" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-03-21 21:51:46
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:QmOnGzUeF0h2wSuAMae2DA
+
+#
+# Enable automatic date handling
+#
+__PACKAGE__->add_columns(
+    "published",
+    { data_type => "datetime", timezone => "UTC", set_on_create => 1, set_on_update => 0, },
+);
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/TopTable/Schema/Result/User.pm
+++ b/lib/TopTable/Schema/Result/User.pm
@@ -547,6 +547,21 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 team_match_reports
+
+Type: has_many
+
+Related object: L<TopTable::Schema::Result::TeamMatchReport>
+
+=cut
+
+__PACKAGE__->has_many(
+  "team_match_reports",
+  "TopTable::Schema::Result::TeamMatchReport",
+  { "foreign.author" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 user_ip_addresses_browsers
 
 Type: has_many
@@ -588,8 +603,8 @@ Composing rels: L</user_roles> -> role
 __PACKAGE__->many_to_many("roles", "user_roles", "role");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-02-12 15:53:56
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5WQryficE9sSSjiGW+qJsw
+# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-03-21 21:51:47
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0/bf09wjOfmvMRQSdLbD2g
 
 use Digest::SHA qw( sha256_hex );
 use Time::HiRes;
@@ -764,6 +779,74 @@ sub reset_password {
   }
   
   return \@errors;
+}
+
+=head2 plays_for
+
+Returns true if the user plays for the specified team in the specified season.
+
+=cut
+
+sub plays_for {
+  my ( $self, $parameters ) = @_;
+  my $team    = $parameters->{team};
+  my $season  = $parameters->{season};
+  
+  # Get the person associated with this user
+  my $person = $self->person;
+  
+  # Return false straight away if there's no person associated
+  return 0 unless defined( $person );
+  
+  # Otherwise return the value of the same routine in the Person model
+  return $person->plays_for({
+    team    => $team,
+    season  => $season,
+  });
+}
+
+=head2 captain_for
+
+Returns true if the user is captain for the specified team in the specified season.
+
+=cut
+
+sub captain_for {
+  my ( $self, $parameters ) = @_;
+  my $team    = $parameters->{team};
+  my $season  = $parameters->{season};
+  
+  # Get the person associated with this user
+  my $person = $self->person;
+  
+  # Return false straight away if there's no person associated
+  return 0 unless defined( $person );
+  
+  # Otherwise return the value of the same routine in the Person model
+  return $person->captain_for({
+    team    => $team,
+    season  => $season,
+  });
+}
+
+=head2 secretary_for
+
+Returns true if the user is secretary for the specified club in the specified season.
+
+=cut
+
+sub secretary_for {
+  my ( $self, $parameters ) = @_;
+  my $club = $parameters->{club};
+  
+  # Get the person associated with this user
+  my $person = $self->person;
+  
+  # Return false straight away if there's no person associated
+  return 0 unless defined( $person );
+  
+  # Otherwise return the value of the same routine in the Person model
+  return $person->secretary_for({club => $club});
 }
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/TopTable/Schema/ResultSet/NewsArticle.pm
+++ b/lib/TopTable/Schema/ResultSet/NewsArticle.pm
@@ -161,6 +161,9 @@ sub create_or_edit {
   $return_value->{error} .= "The article content has not been filled out.\n" if !$raw_article_content;
   
   if ( !$return_value->{error} ) {
+    # Filter the HTML
+    $article_content = TopTable->model("FilterHTML")->filter( $article_content );
+    
     # Get the current year and month
     my $today = DateTime->today( time_zone => "UTC" );
     my ( $published_year, $published_month ) = ( $today->year, $today->month );

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -1473,6 +1473,9 @@ msgstr "Update score"
 msgid "matches.cancel"
 msgstr "Cancel match"
 
+msgid "matches.report"
+msgstr "Write a match report"
+
 msgid "matches.update.form.legend.match-details"
 msgstr "Match details"
 
@@ -1899,6 +1902,27 @@ msgstr "Cancel this match?  (You may revisit this page and untick the box to und
 
 msgid "matches.cancel.points-awarded"
 msgstr "Points to award to %1"
+
+msgid "matches.report.heading"
+msgstr "Match report"
+
+msgid "matches.report.publish-info-no-edits"
+msgstr "Published %1 by %2."
+
+msgid "matches.report.publish-info-with-edits"
+msgstr "Published %1 by %2; edited %3 times, last on %4 by %5."
+
+msgid "matches.report.error.season-not-current"
+msgstr "You cannot create or edit match reports for matches in a season that has been completed."
+
+msgid "matches.report.error.not-authorised"
+msgstr "%1 is not authorised to report on this match."
+
+msgid "matches.report.error.report-blank"
+msgstr "The match report has not been filled out."
+
+msgid "matches.report.success"
+msgstr "The match report has been %1."
 
 ### Generic statistics
 msgid "stats.no-divisions"
@@ -2744,6 +2768,9 @@ msgstr "Delete"
 msgid "admin.update"
 msgstr "Update"
 
+msgid "admin.£"
+msgstr "Report"
+
 msgid "admin.cancel"
 msgstr "Cancel"
 
@@ -2771,6 +2798,9 @@ msgstr "Update %1"
 
 msgid "admin.cancel-object"
 msgstr "Cancel %1"
+
+msgid "admin.report-object"
+msgstr "Report on %1"
 
 msgid "admin.form.invalid-action"
 msgstr "Invalid action (%1) passed; the action must be &#39;create&#39; or &#39;edit&#39;."
@@ -2980,6 +3010,15 @@ msgstr "view matches"
 
 msgid "user.auth.update-matches"
 msgstr "update matches"
+
+msgid "user.auth.create-match-reports"
+msgstr "write a report for this match"
+
+msgid "user.auth.edit-match-reports"
+msgstr "edit this match report"
+
+msgid "user.auth.edit-match-reports"
+msgstr "delete this match report"
 
 msgid "user.auth.cancel-matches"
 msgstr "cancel matches"
@@ -3535,6 +3574,12 @@ msgstr "Cancelled %1%2."
 
 msgid "system-event-log.description.uncancel"
 msgstr "Undid the cancellation for %1%2."
+
+msgid "system-event-log.description.report-create"
+msgstr "Published a match report for %1%2."
+
+msgid "system-event-log.description.report-edit"
+msgstr "Edited a match report for %1%2."
 
 msgid "system-event-log.description.import"
 msgstr "Imported %1%2."

--- a/root/static/css/main.css
+++ b/root/static/css/main.css
@@ -674,6 +674,7 @@ span.player_total_heading {
 span.news-published, #edit-details {
   font-style: italic;
   font-size: 0.9em;
+  margin-bottom: 10px;
 }
 
 div.doubles_home_player_selection, div.doubles_away_player_selection {

--- a/root/templates/html/fixtures-results/view-by-team.ttkt
+++ b/root/templates/html/fixtures-results/view-by-team.ttkt
@@ -111,6 +111,11 @@ END;
       <a href="[% c.uri_for_action("/matches/team/cancel_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0006-Cross-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.cancel") %]" /></a>
 [%
       END;
+      IF match.can_report( c.user );
+-%]
+      <a href="[% c.uri_for_action("/matches/team/report_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0037-Notepad-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.report") %]" /></a>
+[%
+      END;
 -%]
     </td>
 [%

--- a/root/templates/html/fixtures-results/view-group-divisions-no-date.ttkt
+++ b/root/templates/html/fixtures-results/view-group-divisions-no-date.ttkt
@@ -77,6 +77,11 @@ IF matches.count;
       <a href="[% c.uri_for_action("/matches/team/cancel_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0006-Cross-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.cancel") %]" /></a>
 [%
       END;
+      IF match.can_report( c.user );
+-%]
+      <a href="[% c.uri_for_action("/matches/team/report_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0037-Notepad-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.report") %]" /></a>
+[%
+      END;
 -%]
     </td>
 [%

--- a/root/templates/html/fixtures-results/view-group-divisions.ttkt
+++ b/root/templates/html/fixtures-results/view-group-divisions.ttkt
@@ -83,6 +83,11 @@ IF matches.count;
       <a href="[% c.uri_for_action("/matches/team/cancel_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0006-Cross-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.cancel") %]" /></a>
 [%
       END;
+      IF match.can_report( c.user );
+-%]
+      <a href="[% c.uri_for_action("/matches/team/report_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0037-Notepad-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.report") %]" /></a>
+[%
+      END;
 -%]
     </td>
 [%

--- a/root/templates/html/fixtures-results/view-no-grouping-with-division-no-venue.ttkt
+++ b/root/templates/html/fixtures-results/view-no-grouping-with-division-no-venue.ttkt
@@ -73,6 +73,11 @@ IF matches.count;
       <a href="[% c.uri_for_action("/matches/team/cancel_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0006-Cross-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.cancel") %]" /></a>
 [%
       END;
+      IF match.can_report( c.user );
+-%]
+      <a href="[% c.uri_for_action("/matches/team/report_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0037-Notepad-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.report") %]" /></a>
+[%
+      END;
 -%]
     </td>
 [%

--- a/root/templates/html/fixtures-results/view-no-grouping-with-division.ttkt
+++ b/root/templates/html/fixtures-results/view-no-grouping-with-division.ttkt
@@ -75,6 +75,11 @@ IF matches.count;
       <a href="[% c.uri_for_action("/matches/team/cancel_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0006-Cross-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.cancel") %]" /></a>
 [%
       END;
+      IF match.can_report( c.user );
+-%]
+      <a href="[% c.uri_for_action("/matches/team/report_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0037-Notepad-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.report") %]" /></a>
+[%
+      END;
 -%]
     </td>
 [%

--- a/root/templates/html/fixtures-results/view-no-grouping.ttkt
+++ b/root/templates/html/fixtures-results/view-no-grouping.ttkt
@@ -73,6 +73,11 @@ IF matches.count;
       <a href="[% c.uri_for_action("/matches/team/cancel_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0006-Cross-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.cancel") %]" /></a>
 [%
       END;
+      IF match.can_report( c.user );
+-%]
+      <a href="[% c.uri_for_action("/matches/team/report_by_url_keys", [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]"><img src="[% c.uri_for("/static/images/icons/0037-Notepad-icon-16.png") %]" width="16" height="16" title="[% c.maketext("matches.report") %]" /></a>
+[%
+      END;
 -%]
     </td>
 [%

--- a/root/templates/html/matches/team/report.ttkt
+++ b/root/templates/html/matches/team/report.ttkt
@@ -1,0 +1,8 @@
+<form method="post" action="[% form_action %]">
+<fieldset>
+  <legend>[% c.maketext("matches.report.heading") %]</legend>
+  <textarea id="report" name="report" rows="25" cols="100">[% c.flash.report OR latest_report.report %]</textarea><br />
+</fieldset>
+<input type="hidden" name="file_upload_type" id="file_upload_type" value="report" />
+<input type="submit" name="Submit" value="[% c.maketext("form.button.save") %]" />
+</form>

--- a/root/templates/html/matches/team/view.ttkt
+++ b/root/templates/html/matches/team/view.ttkt
@@ -31,7 +31,13 @@ END;
     <li><a href="#teams">[% c.maketext("matches.heading.team-summaries") %]</a></li>
     <li><a href="#players">[% c.maketext("matches.heading.player-summaries") %]</a></li>
     <li><a href="#match-details">[% c.maketext("matches.heading.details") %]</a></li>
+[%
+IF reports;
+-%]
     <li><a href="#report">[% c.maketext("matches.heading.report") %]</a></li>
+[%
+END;
+-%]
   </ul>
   
   <div id="games">
@@ -434,7 +440,27 @@ END;
     </table>
   </div>
   
+[%
+IF reports;
+-%]
   <div id="report">
-    
+[%
+  IF reports > 1;
+    # Report has been edited
+-%]
+
+    <div id="edit-details">[% c.maketext("matches.report.publish-info-with-edits", c.i18n_datetime_format_datetime.format_datetime( original_report.published_date ), original_report.author.display_name, reports - 1, c.i18n_datetime_format_datetime.format_datetime( latest_report.published_date ), latest_report.author.display_name ) %]</div>
+[%
+  ELSE;
+    # Report has not been edited
+-%]
+    <div id="edit-details">[% c.maketext("matches.report.publish-info-no-edits", c.i18n_datetime_format_datetime.format_datetime( original_report.published_date ), original_report.author.display_name ) %]</div>
+[%
+  END;
+-%]
+    <div id="report-text">[% latest_report.report %]</div>
   </div>
+[%
+END;
+-%]
 </div>


### PR DESCRIPTION
* [New] Added match reporting functionality; this includes an update to
the database schema, so run bin/SQL updates/2016-03-15 - match
reports.sql prior to running with this update.
* [Fix] - News article edit - if the user was logged in but was not the
article author, they would be allowed to edit the article even if they
didn't have permission to "edit all".  This has been fixed.
* [Fix] - News article delete - if the user was logged in but was not
the article author, they would be allowed to delete the article even if
they didn't have permission to "delete all".  This has been fixed.