### PR TITLE
Add page descriptions

### DIFF
--- a/lib/TopTable/Controller/Info.pm
+++ b/lib/TopTable/Controller/Info.pm
@@ -59,6 +59,7 @@ Display a contact form.  If the user is logged in, use their user information, o
 
 sub contact :Local {
   my ( $self, $c ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   $c->load_status_msgs;
   
@@ -81,6 +82,7 @@ sub contact :Local {
     external_styles     => [
       $c->uri_for("/static/css/chosen/chosen.min.css"),
     ],
+    page_description    => $c->maketext("description.contact", $site_name),
   });
   
   if ( !$c->user_exists and $c->config->{Google}{reCAPTCHA}{validate_on_contact} and $c->config->{Google}{reCAPTCHA}{site_key} and $c->config->{Google}{reCAPTCHA}{secret_key} ) {

--- a/lib/TopTable/Controller/Info/Officials.pm
+++ b/lib/TopTable/Controller/Info/Officials.pm
@@ -58,13 +58,17 @@ View the current season's league officials (or the last completed season if ther
 
 sub view_current_season :Chained("base") :PathPart("") :Args(0) {
   my ( $self, $c ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   # Get and stash the current season
   my $season = $c->model("DB::Season")->get_current;
   $season = $c->model("DB::Season")->last_complete_season unless defined($season);
   
   if ( defined( $season ) ) {
-    $c->stash({season => $season});
+    $c->stash({
+      season            => $season,
+      page_description  => $c->maketext("description.officials.view-current", $site_name),
+    });
     
     $c->detach( "view_finalise" );
   } else {
@@ -82,13 +86,18 @@ Load and view the specified season's officials.
 
 sub view_specific_season :Chained("base") :PathPart("seasons") :Args(1) {
   my ( $self, $c, $season_id_or_url_key ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   my $season = $c->model("DB::Season")->find_id_or_url_key( $season_id_or_url_key );
   
   if ( defined( $season ) ) {
+    my $encoded_season_name = encode_entities( $season->name );
+    
     $c->stash({
-      season          => $season,
-      specific_season => 1,
+      season              => $season,
+      specific_season     => 1,
+      encoded_season_name => $encoded_season_name,
+      page_description    => $c->maketext("description.officials.view-specific", $site_name, $encoded_season_name),
     });
   
     # Push the season list URI and the current URI on to the breadcrumbs
@@ -184,6 +193,7 @@ Performs the lookups for clubs with the given page number.
 
 sub retrieve_paged_seasons :Private {
   my ( $self, $c, $page_number ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   my $seasons = $c->model("DB::Season")->page_records({
     page_number       => $page_number,
@@ -208,6 +218,7 @@ sub retrieve_paged_seasons :Private {
     subtitle2           => $c->maketext("menu.text.seasons"),
     page_info           => $page_info,
     page_links          => $page_links,
+    page_description    => $c->maketext("description.officials.list-seasons", $site_name),
   });
 }
 

--- a/lib/TopTable/Controller/Info/Rules.pm
+++ b/lib/TopTable/Controller/Info/Rules.pm
@@ -55,13 +55,17 @@ View the current season's rules (or the last completed season if there is no cur
 
 sub view_current_season :Chained("base") :PathPart("") :Args(0) {
   my ( $self, $c ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   # Get and stash the current season
   my $season = $c->model("DB::Season")->get_current;
   $season = $c->model("DB::Season")->last_complete_season unless defined($season);
   
   if ( defined( $season ) ) {
-    $c->stash({season => $season});
+    $c->stash({
+      season            => $season,
+      page_description  => $c->maketext("description.rules.view-current"),
+    });
     
     $c->detach( "view_finalise" );
   } else {
@@ -83,7 +87,10 @@ sub view_specific_season :Chained("base") :PathPart("seasons") :Args(1) {
   my $season = $c->model("DB::Season")->find_id_or_url_key( $season_id_or_url_key );
   
   if ( defined( $season ) ) {
-    $c->stash({season => $season});
+    $c->stash({
+      season            => $season,
+      page_description  => $c->maketext("description.rules.view-specific"),
+    });
   
     # Push the season list URI and the current URI on to the breadcrumbs
     push( @{ $c->stash->{breadcrumbs} }, {

--- a/lib/TopTable/Controller/MeetingTypes.pm
+++ b/lib/TopTable/Controller/MeetingTypes.pm
@@ -78,12 +78,16 @@ Chain base for the list of meeting types.
 
 sub base_list :Chained("/") :PathPart("meeting-types") :CaptureArgs(0) {
   my ( $self, $c ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   # Check that we are authorised to view clubs
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["meeting_view", $c->maketext("user.auth.view-meetings"), 1] );
   
   # Check the authorisation to edit clubs we can display the link if necessary
   $c->forward( "TopTable::Controller::Users", "check_authorisation", [ [ qw( meeting_type_edit meeting_type_delete meeting_type_create) ], "", 0] );
+  
+  # Page description
+  $c->stash({page_description => $c->maketext("description.meeting-types.list", $site_name)});
   
   # Load the messages
   $c->load_status_msgs;
@@ -244,6 +248,7 @@ sub view_finalise :Private {
   my ( $self, $c ) = @_;
   my $meeting_type  = $c->stash->{meeting_type};
   my $encoded_type  = $c->stash->{encoded_type};
+  my $site_name     = $c->stash->{encoded_site_name};
   
   # Set up the title links if we need them
   my @title_links = ();
@@ -272,6 +277,7 @@ sub view_finalise :Private {
     view_online_display => sprintf( "Viewing %s", $encoded_type ),
     view_online_link    => 0,
     canonical_uri       => $c->uri_for_action("/meeting-types/view", [$meeting_type->url_key]),
+    page_description    => $c->maketext("description.meeting-types.view", $encoded_type, $site_name)
   });
 }
 

--- a/lib/TopTable/Controller/Meetings.pm
+++ b/lib/TopTable/Controller/Meetings.pm
@@ -124,6 +124,7 @@ Chain base for the list of seasons.  Matches /seasons
 
 sub base_list :Chained("/") :PathPart("meetings") :CaptureArgs(0) {
   my ( $self, $c ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   # Check that we are authorised to view clubs
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["meeting_view", $c->maketext("user.auth.view-meetings"), 1] );
@@ -131,13 +132,16 @@ sub base_list :Chained("/") :PathPart("meetings") :CaptureArgs(0) {
   # Check the authorisation to edit clubs we can display the link if necessary
   $c->forward( "TopTable::Controller::Users", "check_authorisation", [ [ qw( meeting_edit meeting_delete meeting_create) ], "", 0] );
   
+  # Page description
+  $c->stash({page_description => $c->maketext("description.meetings.list", $site_name)});
+  
   # Load the messages
   $c->load_status_msgs;
 }
 
 =head2 list_first_page
 
-List the clubs on the first page.
+List the meetings on the first page.
 
 =cut
 
@@ -149,7 +153,7 @@ sub list_first_page :Chained("base_list") :PathPart("") :Args(0) {
 
 =head2 list_specific_page
 
-List the clubs on the specified page.
+List the meetings on the specified page.
 
 =cut
 
@@ -236,6 +240,7 @@ sub view :Private {
   my $event                 = $c->stash->{event};
   my $event_season          = $c->stash->{event_season};
   my $encoded_meeting_type  = $c->stash->{encoded_meeting_type};
+  my $site_name             = $c->stash->{encoded_site_name};
   my ( $edit_uri, $delete_uri, $edit_auth_code, $delete_auth_code, $name, $meeting );
   
   if ( $is_event ) {
@@ -302,6 +307,7 @@ sub view :Private {
     view_online_display => sprintf( "Viewing %s", $name ),
     view_online_link    => 0,
     canonical_uri       => $canonical_uri,
+    page_description    => $c->maketext("description.meetings.view", $name, $site_name),
   });
 }
 

--- a/lib/TopTable/Controller/News.pm
+++ b/lib/TopTable/Controller/News.pm
@@ -116,6 +116,7 @@ Chain base for the list of news articles.  Matches /news
 
 sub base_list :Chained("/") :PathPart("news") :CaptureArgs(0) {
   my ( $self, $c ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   # Check that we are authorised to view venues
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["news_article_view", $c->maketext("user.auth.view-news"), 1] );
@@ -124,6 +125,9 @@ sub base_list :Chained("/") :PathPart("news") :CaptureArgs(0) {
   $c->forward( "TopTable::Controller::Users", "check_authorisation", [[ qw( news_article_create news_article_edit_all news_article_delete_all ) ], "", 0] );
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["news_article_edit_own", "", 0] ) if $c->user_exists and !$c->stash->{authorisation}{news_article_edit_all}; # Only do this if the user is logged in and we can't edit all articles
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["news_article_delete_own", "", 0] ) if $c->user_exists and !$c->stash->{authorisation}{news_article_delete_all}; # Only do this if the user is logged in and we can't delete all articles
+  
+  # Page description
+  $c->stash({page_description => $c->maketext("description.news.list", $site_name)});
   
   # Load the messages
   $c->load_status_msgs;
@@ -263,6 +267,7 @@ sub view :Private {
     view_online_display => "Viewing " . $current_details->{headline},
     view_online_link    => 1,
     canonical_uri       => $c->uri_for_action("/news/view_by_url_key", [$article->published_year, sprintf("%02d", $article->published_month), $article->url_key]),
+    page_description    => $article->article_description,
   });
 }
 

--- a/lib/TopTable/Controller/Roles.pm
+++ b/lib/TopTable/Controller/Roles.pm
@@ -76,12 +76,16 @@ Chain base for the list of roles.
 
 sub base_list :Chained("/") :PathPart("roles") :CaptureArgs(0) {
   my ( $self, $c ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   # Check that we are authorised to view clubs
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["role_view", $c->maketext("user.auth.view-roles"), 1] );
   
   # Check the authorisation to edit clubs we can display the link if necessary
   $c->forward( "TopTable::Controller::Users", "check_authorisation", [ [ qw( role_create role_edit role_delete ) ], "", 0] );
+  
+  # Page description
+  $c->stash({page_description => $c->maketext("description.roles.list", $site_name)});
   
   # Load the messages
   $c->load_status_msgs;
@@ -163,7 +167,8 @@ View the role (i.e., name, permissions and  members).
 sub view :Chained("base") :PathPart("") :Args(0) {
   my ( $self, $c ) = @_;
   my $role = $c->stash->{role};
-  my $encoded_name = $c->stash->{encoded_name};
+  my $site_name = $c->stash->{encoded_site_name};
+  my $role_name = $c->stash->{encoded_name};
   
   # Check that we are authorised to view
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["role_view", $c->maketext("user.auth.view-roles"), 1] );
@@ -176,14 +181,14 @@ sub view :Chained("base") :PathPart("") :Args(0) {
     # Push edit / opening hour links if are authorised
     push(@title_links, {
       image_uri => $c->uri_for("/static/images/icons/0018-Pencil-icon-32.png"),
-      text      => $c->maketext("admin.delete-object", $encoded_name),
+      text      => $c->maketext("admin.delete-object", $role_name),
       link_uri  => $c->uri_for_action("/roles/edit", [$role->url_key]),
     }) if $c->stash->{authorisation}{role_edit};
     
     # Push a delete link if we're authorised and the venue can be deleted
     push(@title_links, {
       image_uri => $c->uri_for("/static/images/icons/0005-Delete-icon-32.png"),
-      text      => $c->maketext("admin.delete-object", $encoded_name),
+      text      => $c->maketext("admin.delete-object", $role_name),
       link_uri  => $c->uri_for_action("/roles/delete", [$role->url_key]),
     }) if $c->stash->{authorisation}{role_delete};
   }
@@ -192,8 +197,9 @@ sub view :Chained("base") :PathPart("") :Args(0) {
   $c->stash({
     template            => "html/roles/view.ttkt",
     title_links         => \@title_links,
-    view_online_display => sprintf( "Viewing role: %s", $encoded_name ),
+    view_online_display => sprintf( "Viewing role: %s", $role_name ),
     view_online_link    => 0,
+    page_description    => $c->maketext("description.roles.view", $role_name, $site_name),
   });
 }
 

--- a/lib/TopTable/Controller/Root.pm
+++ b/lib/TopTable/Controller/Root.pm
@@ -41,7 +41,10 @@ sub auto :Private {
   
   # Stash the correct timezone
   # Only do timezone stuff if we're not processing a js file
-  $c->stash({timezone => $c->timezone}) unless $c->request->path =~ /\.js$/;
+  $c->stash({
+    timezone          => $c->timezone,
+    encoded_site_name => encode_entities( $c->config->{name} ),
+  }) unless $c->request->path =~ /\.js$/;
 }
 
 =head2 begin

--- a/lib/TopTable/Controller/Seasons.pm
+++ b/lib/TopTable/Controller/Seasons.pm
@@ -75,12 +75,16 @@ Chain base for the list of seasons.  Matches /seasons
 
 sub base_list :Chained("/") :PathPart("seasons") :CaptureArgs(0) {
   my ( $self, $c ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   # Check that we are authorised to view clubs
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["season_view", $c->maketext("user.auth.view-seasons"), 1] );
   
   # Check the authorisation to edit clubs we can display the link if necessary
   $c->forward( "TopTable::Controller::Users", "check_authorisation", [ [ qw( season_edit season_delete season_create) ], "", 0] );
+  
+  # Page description
+  $c->stash({page_description => $c->maketext("description.seasons.list", $site_name)});
   
   # Load the messages
   $c->load_status_msgs;
@@ -161,6 +165,7 @@ sub view :Chained("base") :PathPart("") :Args(0) {
   my ( $self, $c ) = @_;
   my $season        = $c->stash->{season};
   my $encoded_name  = $c->stash->{encoded_name};
+  my $site_name     = $c->stash->{encoded_site_name};
   my $edit_teams_allowed;
   
   # Check that we are authorised to view clubs
@@ -205,6 +210,7 @@ sub view :Chained("base") :PathPart("") :Args(0) {
     divisions           => $divisions,
     edit_teams_allowed  => $edit_teams_allowed,
     canonical_uri       => $c->uri_for_action("/seasons/view", [$season->url_key]),
+    page_description    => $c->maketext("description.seasons.view", $encoded_name, $site_name),
   });
 }
 

--- a/lib/TopTable/Controller/SystemEventLog.pm
+++ b/lib/TopTable/Controller/SystemEventLog.pm
@@ -44,12 +44,16 @@ Base routine for the event log listing.  Checks the authorisation.
 
 sub base :Chained("/") :PathPart("event-log") :CaptureArgs(0) {
   my ( $self, $c ) = @_;
-  
-  # Load the messages
-  $c->load_status_msgs;
+  my $site_name = $c->stash->{encoded_site_name};
   
   # Check that we are authorised to view clubs
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["system_event_log_view_all", "view administrative updates", 0] );
+  
+  # Page description
+  $c->stash({page_description => $c->maketext("description.event-log.list", $site_name)});
+  
+  # Load the messages
+  $c->load_status_msgs;
 }
 
 =head2 list_first_page

--- a/lib/TopTable/Controller/Users.pm
+++ b/lib/TopTable/Controller/Users.pm
@@ -87,6 +87,7 @@ Chain base for the list of clubs.  Matches /clubs
 
 sub base_list :Chained("/") :PathPart("users") :CaptureArgs(0) {
   my ( $self, $c ) = @_;
+  my $site_name = $c->stash->{encoded_site_name};
   
   # Check that we are authorised to view users
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["user_view", $c->maketext("user.auth.view-users"), 1] );
@@ -95,6 +96,9 @@ sub base_list :Chained("/") :PathPart("users") :CaptureArgs(0) {
   $c->forward( "TopTable::Controller::Users", "check_authorisation", [ [ qw( user_edit_all user_delete_all ) ], "", 0] );
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["user_edit_own", "", 0] ) if $c->user_exists and !$c->stash->{authorisation}{news_article_edit_all}; # Only do this if the user is logged in and we can't edit all articles
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["user_delete_own", "", 0] ) if $c->user_exists and !$c->stash->{authorisation}{news_article_delete_all}; # Only do this if the user is logged in and we can't delete all articles
+  
+  # Page description
+  $c->stash({page_description => $c->maketext("description.users.list", $site_name)});
   
   # Load the messages
   $c->load_status_msgs;
@@ -172,8 +176,9 @@ View a user's profile.
 
 sub view :Chained("base") :PathPart("") :Args(0) {
   my ( $self, $c ) = @_;
-  my $user = $c->stash->{user};
-  my $encoded_username = $c->stash->{encoded_username};
+  my $user              = $c->stash->{user};
+  my $encoded_username  = $c->stash->{encoded_username};
+  my $site_name         = $c->stash->{encoded_site_name};
   
   # Set up the title links if we need them
   my @title_links = ();
@@ -193,9 +198,10 @@ sub view :Chained("base") :PathPart("") :Args(0) {
   }) if $c->stash->{authorisation}{user_delete_all} or ( $c->stash->{authorisation}{user_delete_own} and $c->user_exists and $c->user->id == $user->id );
   
   $c->stash({
-    template      => "html/users/view.ttkt",
-    title_links   => \@title_links,
-    canonical_uri => $c->uri_for_action("/users/view", [$user->url_key]),
+    template          => "html/users/view.ttkt",
+    title_links       => \@title_links,
+    canonical_uri     => $c->uri_for_action("/users/view", [$user->url_key]),
+    page_description  => $c->maketext("description.users.view", $encoded_username, $site_name),
   });
 }
 

--- a/lib/TopTable/Schema/Result/NewsArticle.pm
+++ b/lib/TopTable/Schema/Result/NewsArticle.pm
@@ -319,6 +319,22 @@ sub current_details {
   return $return_value;
 }
 
+=head2 article_description
+
+Returns an article description of either a brief description field (to be created) or the first 150 characters of the article itself.
+
+=cut
+
+sub article_description {
+  my ( $self ) = @_;
+  
+  # Get the current details so we access the latest edit
+  my $current_article_text = $self->current_details->{article_content};
+  
+  # Return a substring of the article
+  return substr( $current_article_text, 0, 150 );
+}
+
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -344,6 +344,199 @@ msgstr "are"
 msgid "home-page.todays-matches"
 msgstr "Matches playing today"
 
+### Page descriptions
+## Clubs
+msgid "description.clubs.list"
+msgstr "A list of clubs that play, or have played in %1."
+
+msgid "description.clubs.view-current"
+msgstr "%1 team listings, secretary and venue details in %2."
+
+msgid "description.clubs.view-specific"
+msgstr "%1 team listings (%2) in %3."
+
+msgid "description.clubs.list-seasons"
+msgstr "Seasons that %1 has entered teams into %2."
+
+## Divisions
+msgid "description.divisions.list"
+msgstr "A list of divisions in %1, including past divisions that may not currently be in use."
+
+msgid "description.divisions.view-current"
+msgstr "League tables and league averages (singles, individual doubles, doubles pairs and teams) for %1 in %2."
+
+msgid "description.divisions.view-specific"
+msgstr "%3 league tables and league averages (singles, individual doubles, doubles pairs and teams) for %1 in %2."
+
+msgid "description.divisions.list-seasons"
+msgstr "Seasons that %1 has been used in %2."
+
+## Events
+msgid "description.events.list"
+msgstr "A list of events in %1."
+
+msgid "description.clubs.view-current"
+msgstr "Event information for %1 in %2."
+
+msgid "description.clubs.view-specific"
+msgstr "Event information for %1 %3 in %2."
+
+msgid "description.events.list-seasons"
+msgstr "Seasons that %1 has been organised in %2."
+
+## Fixtures grids
+msgid "description.fixtures-grids.list"
+msgstr "A list of fixtures grids available for use in %1."
+
+msgid "description.fixtures-grids.view-current"
+msgstr "Teams assigned to the fixtures grid &#39;%1&#39 and weeks that they play each other."
+
+msgid "description.fixtures-grids.view-specific"
+msgstr "Teams assigned to the fixtures grid &#39;%1&#39 in %3 and weeks that they play each other."
+
+msgid "description.fixtures-grids.list-seasons"
+msgstr "Seasons that %1 has been used in %2."
+
+## Fixtures / Results
+# TODO
+
+## Info pages
+msgid "description.contact"
+msgstr "Send a message to %1."
+
+msgid "description.officials.view-current"
+msgstr "League officials for %1."
+
+msgid "description.officials.view-specific"
+msgstr "League officials (%2) for %1."
+
+msgid "description.officials.list-seasons"
+msgstr "A list of seasons that you can view league officials for on %1."
+
+msgid "description.rules.view-current"
+msgstr "League rules for %1."
+
+msgid "description.rules.view-specific"
+msgstr "League rules (%2) for %1."
+
+## League averages
+msgid "description.league-averages.options"
+msgstr "League averages for %1 - choose from singles, individual doubles, doubles pairs or team doubles performances."
+
+msgid "description.league-averages.list-divisions"
+msgstr "A list of divisions in %1 to view league averages for."
+
+msgid "description.league-averages.view-current"
+msgstr "League averages (%1) in %2 of %3."
+
+msgid "description.league-averages.view-specific"
+msgstr "%4 league averages (%1) in %2 of %3."
+
+msgid "description.league-averages.list-seasons"
+msgstr "A list of seasons that you can view %1 league averages for in %2."
+
+## League tables
+msgid "description.league-tables.list-divisions"
+msgstr "A list of divisions in %1 to view league tables for."
+
+msgid "description.league-tables.view-current"
+msgstr "League tables in %1 of %2."
+
+msgid "description.league-tables.view-specific"
+msgstr "%3 league tables in %1 of %2."
+
+msgid "description.league-tables.list-seasons"
+msgstr "A list of seasons that you can view %1 league tables for in %2."
+
+## Matches
+msgid "description.team-matches.view-not-started"
+msgstr "%1 details for the match due to take place on %2."
+
+msgid "description.team-matches.view-cancelled"
+msgstr "%1 details for the cancelled match, which was due to take place on %2."
+
+msgid "description.team-matches.view-started"
+msgstr "%1 match details (current score: %2)"
+
+msgid "description.team-matches.view-completed"
+msgstr "%1 match details (final score: %2), which took place on %3."
+
+## Meetings
+msgid "description.meetings.list"
+msgstr "A list of meetings that are available to view in %1."
+
+msgid "description.meetings.view"
+msgstr "The agenda, attendees, apologies and minutes for %1 in %2."
+
+## Meeting types
+msgid "description.meeting-types.list"
+msgstr "List of meeting types available for use in %1."
+
+msgid "description.meeting-types.view"
+msgstr "A list of %1 on %2."
+
+## News
+msgid "description.news.list"
+msgstr "List of news articles available to view on %1."
+
+## People
+msgid "description.people.list"
+msgstr "A list of current and historic people who have played in or been involved with %1."
+
+msgid "description.people.view-current"
+msgstr "%1&#39;s page on %2, including player statistics, match results and teams they have played for."
+
+msgid "description.people.view-current"
+msgstr "%1&#39;s page from %3 on %2, including player statistics, match results and teams they have played for."
+
+msgid "description.people.list-seasons"
+msgstr "A list of seasons that %1 has played in or been involved with %2."
+
+## Roles
+msgid "description.roles.list"
+msgstr "A list of user roles on the %1 web site."
+
+msgid "description.roles.view"
+msgstr "Permission details and users who are a member of the role &#39;%1&#39; in %2."
+
+## Seasons
+msgid "description.seasons.list"
+msgstr "A list of seasons available to view on %1."
+
+msgid "description.seasons.view"
+msgstr "%1 results, league tables, league averages, match results, team and player statistics in %2."
+
+## System event log
+msgid "description.event-log.list"
+msgstr "A list of updates on the %1 web site."
+
+## Teams
+msgid "description.teams.list"
+msgstr "A list of teams grouped by current club (or the last club they entered through) that are currently playing in or have in the past entered %1."
+
+msgid "description.teams.view-current"
+msgstr "%1 fixtures, results, player lists and statistics in %2."
+
+msgid "description.teams.view-specific"
+msgstr "%1 results, player lists and statistics for %3 in %2."
+
+msgid "description.teams.list-seasons"
+msgstr "Seasons that %1 has entered teams into %2."
+
+## Users
+msgid "description.users.list"
+msgstr "A list of users registered on the %1 web site."
+
+msgid "description.users.view"
+msgstr "%1's user profile on %2."
+
+## Venues
+msgid "description.venues.list"
+msgstr "A list of the venues available for %1."
+
+msgid "description.venues.view"
+msgstr "Address and contact details for %1, get directions and see when you can play table tennis there.  %1 is a venue in %2."
+
 ### Clubs
 msgid "clubs.create"
 msgstr "Create a new club"
@@ -530,7 +723,7 @@ msgid "teams.name.changed-notice"
 msgstr "%1 %2 is now known as %3 %4."
 
 msgid "teams.tokeninput.type"
-msgstr "Start typing a team or club's name"
+msgstr "Start typing a team or club&#39;s name"
 
 msgid "teams.tokeninput.type-captain"
 msgstr "A person can captain multiple teams - select as many as you need"
@@ -660,7 +853,7 @@ msgid "people.create-for"
 msgstr "Create a new person playing for %1 %2"
 
 msgid "person.tokeninput.type"
-msgstr "Start typing a person's name"
+msgstr "Start typing a person&#39;s name"
 
 msgid "people.create.no-season"
 msgstr "There is no current season, so people cannot be created - create a new season first."
@@ -846,10 +1039,10 @@ msgid "people.form.import-results.no-file-uploaded"
 msgstr "No file was uploaded; please browse to a file on your system."
 
 msgid "people.form.import-results.field-heading-invalid"
-msgstr "The field heading: '%1' is not valid."
+msgstr "The field heading: &#39;%1&#39; is not valid."
 
 msgid "people.form.import-results.secretary-club-invalid"
-msgstr "The secretaried club is not valid; please supply the club's short name."
+msgstr "The secretaried club is not valid; please supply the club&#39;s short name."
 
 msgid "people.form.import-results.gender-invalid"
 msgstr "The specified gender is invalid."
@@ -864,7 +1057,7 @@ msgid "people.form.import-results.team-not-specified"
 msgstr "The %1 team has not been specified; remove the %1 club or add a team that belongs to the specified club."
 
 msgid "people.form.import-results.club-invalid"
-msgstr "The %1 club is not valid; please supply the club's short name."
+msgstr "The %1 club is not valid; please supply the club&#39;s short name."
 
 msgid "people.form.import-results.club-not-specified"
 msgstr "The %1 team has been specified without a club."
@@ -2185,16 +2378,16 @@ msgid "average-filter.form.error.no-player-types"
 msgstr "You must select at least one player type to display."
 
 msgid "average-filter.form.error.criteria-field-invalid"
-msgstr "The criteria field must be 'played', 'won' or 'lost'."
+msgstr "The criteria field must be &#39;played&#39;, &#39;won&#39; or &#39;lost&#39;."
 
 msgid "average-filter.form.error.criteria-invalid"
 msgstr "The criteria must be a numeric value"
 
 msgid "average-filter.form.error.operator-invalid"
-msgstr "The operator must be 'more than', 'at least', 'exactly', 'at most' or 'less than'."
+msgstr "The operator must be &#39;more than&#39;, &#39;at least&#39;, &#39;exactly&#39;, &#39;at most&#39; or &#39;less than&#39;."
 
 msgid "average-filter.form.error.criteria-type-invalid"
-msgstr "The criteria field must be 'matches' or 'games'."
+msgstr "The criteria field must be &#39;matches&#39; or &#39;games&#39;."
 
 msgid "average-filter.view-list"
 msgstr "View average filters"
@@ -2369,7 +2562,7 @@ msgid "events.form.error.finish-minute-invalid"
 msgstr "The event finish minute value is invalid; it must be selected from the list (&#39;00&#39; to &#39;59&#39;), or you must select &#39;all day&#39;."
 
 msgid "events.form.error.cant-edit-event-type"
-msgstr "The event type can't be edited because it has either been used in previous seasons with the current type or there are matches / meetings associated with it already."
+msgstr "The event type can&#39;t be edited because it has either been used in previous seasons with the current type or there are matches / meetings associated with it already."
 
 msgid "events.edit.error.no-current-season"
 msgstr "You can&#39;t edit events until there is a current season to edit them in."
@@ -2466,7 +2659,7 @@ msgid "meetings.form.error.attendee-list-not-array"
 msgstr "The list of attendees must be passed as an array."
 
 msgid "meetings.form.error.apologies-list-not-array"
-msgstr "The list of people who've apologised for not attending must be passed as an array."
+msgstr "The list of people who&#39;ve apologised for not attending must be passed as an array."
 
 msgid "meetings.form.error.attendee-on-both-lists"
 msgstr "%1 is listed as having both attended and sent their apologies; please remove %2 from one or both lists."
@@ -2722,7 +2915,7 @@ msgid "contact-reasons.form.error.no-recipients"
 msgstr "No recipients have been specified."
 
 msgid "contact-reasons.form.error.no-email-for-person"
-msgstr "%1 cannot be added as a contact recipient, because they don't have an email address stored; you'll need to edit their details and add an email address first."
+msgstr "%1 cannot be added as a contact recipient, because they don&#39;t have an email address stored; you&#39;ll need to edit their details and add an email address first."
 
 ### Contact form
 msgid "contact.form.legend.details"
@@ -3313,10 +3506,10 @@ msgid "user.retrieve-username.error.email-address-missing"
 msgstr "Please fill out your email address."
 
 msgid "user.retrieve-username.form-submit-notice"
-msgstr "Thank you for filling our your username; if it's you have an account registered to that email address, your username will be emailed to you."
+msgstr "Thank you for filling our your username; if it&#39;s you have an account registered to that email address, your username will be emailed to you."
 
 msgid "user.forgot-password.error.username-missing"
-msgstr "Please fill out your username.  If you can't remember what it is, you must retrieve it <a href="%1">here</a> first."
+msgstr "Please fill out your username.  If you can&#39;t remember what it is, you must retrieve it <a href="%1">here</a> first."
 
 msgid "user.forgot-password.error.failed-to-set-key"
 msgstr "Failed to generate a password reset link.  Please try again or contact the administrator if the error persists."
@@ -3440,10 +3633,10 @@ msgid "role.permission.user.delete-all"
 msgstr "Delete any user"
 
 msgid "role.permission.user.view-ip"
-msgstr "View users' IP addresses"
+msgstr "View users&#39; IP addresses"
 
 msgid "role.permission.user.view-user-agent"
-msgstr "View users' browsers"
+msgstr "View users&#39; browsers"
 
 msgid "role.permission.system-event-log.view-all"
 msgstr "View private events"
@@ -3517,10 +3710,10 @@ msgid "msg.view-contact-details"
 msgstr "View contact details"
 
 msgid "msg.insecure-password-form"
-msgstr "This web site is not currently being served on a secure connection and you are about to fill in a form that has a password field; it's recommended that you use the <a href="%1">secure form</a> instead if possible, but bear in mind that the security certificate uses modern ciphers that are not compatible with Windows XP (which itself is no longer supported by Microsoft)."
+msgstr "This web site is not currently being served on a secure connection and you are about to fill in a form that has a password field; it&#39;s recommended that you use the <a href="%1">secure form</a> instead if possible, but bear in mind that the security certificate uses modern ciphers that are not compatible with Windows XP (which itself is no longer supported by Microsoft)."
 
 msgid "msg.cookie-notice"
-msgstr "We use cookies on this website to track user sessions and for Google Analytics. To use the website as intended, click 'accept'.  Continued use of this website also implies acceptance."
+msgstr "We use cookies on this website to track user sessions and for Google Analytics. To use the website as intended, click &#39;accept&#39;.  Continued use of this website also implies acceptance."
 
 ### Genders
 msgid "gender.male.gender"
@@ -4012,7 +4205,7 @@ msgstr "%1: %2, your user account has been activated"
 
 msgid "email.html.users.activated"
 msgstr "Hi %1<br /><br />\n\n"
-"Your account on %2 has now been activated and you may login by clicking <a href="%3">here</a> and entering your username and the password you created during the registration process.  If the link doesn't work, you can copy and paste the next line into your browser&#39;s address bar.<br /><br />\n\n"
+"Your account on %2 has now been activated and you may login by clicking <a href="%3">here</a> and entering your username and the password you created during the registration process.  If the link doesn&#39;t work, you can copy and paste the next line into your browser&#39;s address bar.<br /><br />\n\n"
 "%3<br /><br />\n\n"
 "Regards,<br /><br /><br />\n\n\n"
 "%2<br />\n"

--- a/root/templates/html/fixtures-results/view-by-team.ttkt
+++ b/root/templates/html/fixtures-results/view-by-team.ttkt
@@ -82,7 +82,7 @@ END;
     </td>
     <td data-label="[% c.maketext("teams.fixtures.score") %]">
 [%
-IF match.started AND !match.cancelled;
+IF match.started OR match.cancelled;
 -%]
       <a href="[% c.uri_for_action('/matches/team/view_by_url_keys', [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match_result.score %]</a>
 [%

--- a/root/templates/html/fixtures-results/view-group-divisions-no-date.ttkt
+++ b/root/templates/html/fixtures-results/view-group-divisions-no-date.ttkt
@@ -57,7 +57,7 @@ IF matches.count;
       <a href="[% c.uri_for_action('/matches/team/view_by_url_keys', [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a>
     </td>
     <td>
-      <a href="[% away_team_uri %]">[% match.away_team.club.short_name | html_entity %] [% match.away_team.namev %]</a>
+      <a href="[% away_team_uri %]">[% match.away_team.club.short_name | html_entity %] [% match.away_team.name %]</a>
     </td>
     <td>
       <a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a>

--- a/root/templates/html/league-averages/view-options.ttkt
+++ b/root/templates/html/league-averages/view-options.ttkt
@@ -11,3 +11,6 @@
 <div class="list-item">
   <a href="[% c.uri_for_action('/league-averages/list_first_page', ['doubles-pairs']) %]">Doubles (Pairs)</a><br />
 </div>
+<div class="list-item">
+  <a href="[% c.uri_for_action('/league-averages/list_first_page', ['teams']) %]">Teams</a><br />
+</div>

--- a/root/templates/html/wrappers/responsive.ttkt
+++ b/root/templates/html/wrappers/responsive.ttkt
@@ -21,7 +21,10 @@ END;
 <meta name="mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-title" content="MK Table Tennis League" />
 
-<!-- Social -->
+<!-- Social / SEO -->
+<meta name="description" content="[% page_description OR c.config.site_description %]" />
+<meta name="author" content="Chris Welch" />
+
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@MKChris">
 [%
@@ -32,15 +35,15 @@ IF c.config.social.twitter_account;
 END;
 -%]
 <meta name="twitter:title" content="[% page_title %]" />
-<meta name="twitter:description" content="[% social_description OR c.config.site_description %]" />
+<meta name="twitter:description" content="[% page_description OR c.config.site_description %]" />
 <meta name="twitter:image" content="[% c.uri_for("/static/images/social/twitter.png") %]" />
 
 <meta property="og:title" content="[% page_title %]" />
-<meta property="og:description" content="[% social_description OR c.config.site_description %]" />
+<meta property="og:description" content="[% page_description OR c.config.site_description %]" />
 <meta property="og:type" content="website">
 <meta property="og:url" content="[% canonical_uri OR c.uri_for( c.request.path ) %]" />
 <meta property="og:image" content="[% c.uri_for("/static/images/social/facebook.png") %]" />
-<!-- End social -->
+<!-- End social / SEO -->
 
 <link rel="apple-touch-icon"  sizes="57x57"   href="[% c.uri_for("/static/images/web-app/web-app-icon-57x57.png") %]" />
 <link rel="apple-touch-icon"  sizes="72x72"   href="[% c.uri_for("/static/images/web-app/web-app-icon-72x72.png") %]" />


### PR DESCRIPTION
* [New] Added page descriptions to meta tags for social media and search
engines.
* [Fix] Fixed an issue when viewing fixtures and results for an
individual day, where the away team was only displaying the club short
name and not the team name afterwards.

Closes #21 
Fixes #26 