### PR TITLE
Server-side processing for event viewer table

### DIFF
--- a/lib/TopTable.pm
+++ b/lib/TopTable.pm
@@ -73,9 +73,10 @@ __PACKAGE__->config(
   disable_component_resolution_regex_fallback => 1, # Disable deprecated behavior needed by old applications
   enable_catalyst_header => 1, # Send X-Catalyst header
   "View::JSON" => {
-    allow_callback  => 1,    # defaults to 0
-    callback_param  => 'cb', # defaults to 'callback'
-    expose_stash    => qr/(^json|^link$|^error$)/,
+    allow_callback => 1,    # defaults to 0
+    callback_param => 'cb', # defaults to 'callback'
+    expose_stash => "json_data",
+    #expose_stash    => qr/(^json|^link$|^error$)/,
     #expose_stash    => [ "link", "error", qr/^json/ ], # defaults to everything
   },
   "CatalystX::DebugFilter" => {

--- a/lib/TopTable/Controller/Files.pm
+++ b/lib/TopTable/Controller/Files.pm
@@ -227,7 +227,7 @@ sub do_upload :Path("do-upload") :Args(0) {
   }
   
   if ( $return_json ) {
-    $c->stash($return_value);
+    $c->stash({json_data => $return_value});
     $c->detach( $c->view("JSON") );
   }
 }

--- a/lib/TopTable/Controller/Images.pm
+++ b/lib/TopTable/Controller/Images.pm
@@ -201,7 +201,7 @@ sub do_upload :Path("do-upload") :Args(0) {
   }
   
   if ( $return_json ) {
-    $c->stash($return_value);
+    $c->stash({json_data => $return_value});
     $c->detach( $c->view("JSON") );
   }
 }

--- a/lib/TopTable/Controller/Matches/Team.pm
+++ b/lib/TopTable/Controller/Matches/Team.pm
@@ -508,9 +508,11 @@ sub update_game_score :Private {
   # Stash something to say the request was okay
   if ( $c->is_ajax ) {
     $c->stash({
-      json_status               => "Okay",
-      json_originally_complete  => $update_result->{match_originally_complete},
-      json_match_complete       => $update_result->{match}->complete,
+      json_data => {
+        json_status => "Okay",
+        json_originally_complete => $update_result->{match_originally_complete},
+        json_match_complete => $update_result->{match}->complete,
+      }
     });
     
     $c->detach( $c->view("JSON") );
@@ -557,7 +559,7 @@ sub update_js :Private {
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["match_update", $c->maketext("user.auth.update-matches"), 1] );
   
   # This will be a javascript file, not a HTML
-  $c->response->headers->header("Content-type" => "text/javascript");
+  $c->res->header( "Content-type" => "text/javascript" );
   
   # Stash no wrapper and the template
   $c->stash({
@@ -625,7 +627,10 @@ sub change_played_date :Private {
   
   # Stash something to say the request was okay
   if ( $c->is_ajax ) {
-    $c->stash({json_status  => "Okay",});
+    $c->stash({
+      json_data => {json_status  => "Okay"}
+    });
+    
     $c->detach( $c->view("JSON") );
   }
 }
@@ -685,7 +690,10 @@ sub change_venue :Private {
   } else {
     # Success
     if ( $c->is_ajax ) {
-      $c->stash({json_status  => "Okay",});
+      $c->stash({
+        json_data => {json_status  => "Okay"}
+      });
+      
       $c->detach( $c->view("JSON") );
     }
   }
@@ -753,16 +761,17 @@ sub get_player_lists :Private {
   
   # Stash our values
   $c->stash({
-    home_player_list        => \@home_player_list,
-    away_player_list        => \@away_player_list,
-    home_doubles_list       => $home_doubles_list,
-    away_doubles_list       => $away_doubles_list,
+    home_player_list => \@home_player_list,
+    away_player_list => \@away_player_list,
+    home_doubles_list => $home_doubles_list,
+    away_doubles_list => $away_doubles_list,
+    skip_view_online        => 1, # Don't alter the view who's online activity
     
     # No encoding for this, as we're forwarding to a JSON view that will do it for us
-    json_home_doubles_list  => $home_doubles_list,
-    json_away_doubles_list  => $away_doubles_list,
-    # Don't alter the view who's online activity
-    skip_view_online        => 1,
+    json_data => {
+      json_home_doubles_list => $home_doubles_list,
+      json_away_doubles_list => $away_doubles_list,
+    }
   });
   
   # Detach to the JSON view if required
@@ -811,6 +820,10 @@ sub update_playing_order :Private {
     $c->detach( "TopTable::Controller::Root", "json_error", [400, $error] );
   } else {
     # Detach to the JSON view
+    $c->stash({
+      json_data => {json_status  => "Okay"}
+    });
+    
     $c->detach( $c->view("JSON") );
   }
 }

--- a/lib/TopTable/Controller/Matches/Team/Game.pm
+++ b/lib/TopTable/Controller/Matches/Team/Game.pm
@@ -167,7 +167,9 @@ sub update_umpire :Private {
       $message = $c->maketext("matches.umpire.remove.success", $game->scheduled_game_number);
     }
     
-    $c->stash({json_message => $message});
+    $c->stash({
+      json_data => {json_message => $message}
+    });
   }
   
   # Detach to the JSON view
@@ -228,7 +230,6 @@ sub doubles_pair :Private {
     
     if ( $c->is_ajax ) {
       # Stash the original player so any select lists or inputs can be reset to their old values
-      $c->stash({json_player => $actioned->{original_player}});
       $c->detach( "TopTable::Controller::Root", "json_error", [400, $error] );
     } else {
       $c->log->error( $error );
@@ -245,7 +246,8 @@ sub doubles_pair :Private {
     }
     
     $c->stash({
-      json_message  => $message, # Stash the message to display, so we can provide it in the correct language to the client script
+      json_data => {json_message => $message}, # Stash the message to display, so we can provide it in the correct language to the client script
+      json_player => $actioned->{original_player}
     });
   }
   

--- a/lib/TopTable/Controller/Matches/Team/Player.pm
+++ b/lib/TopTable/Controller/Matches/Team/Player.pm
@@ -174,7 +174,11 @@ sub update :Private {
     
     if ( $c->is_ajax ) {
       # Stash the original player so any select lists or inputs can be reset to their old values
-      $c->stash({json_player => $details->{original_player}});
+      $c->stash({
+        json_data => {
+          json_player => $details->{original_player}
+        }
+      });
       $c->detach( "TopTable::Controller::Root", "json_error", [400, $error] );
     } else {
       $c->log->error( $error );
@@ -195,7 +199,11 @@ sub update :Private {
     
     $c->stash({
       json_player_games => $details->{player_games},
-      json_message      => $message, # Stash the message to display, so we can provide it in the correct language to the client script
+      json_message => $message, # Stash the message to display, so we can provide it in the correct language to the client script
+      json_data => {
+        json_player_games => $details->{player_games},
+        json_message => $message, # Stash the message to display, so we can provide it in the correct language to the client script
+      }
     });
   }
   

--- a/lib/TopTable/Controller/People.pm
+++ b/lib/TopTable/Controller/People.pm
@@ -707,7 +707,7 @@ sub create_with_team :Private {
   if ( defined ( $team ) ) {
     # We just update the prePopulate first element of the tokenInput arrays, as this is the team
     $c->stash->{tokeninput_confs}[0]{options} = encode_json({
-      jsonContainer => "json_teams",
+      jsonContainer => "json_search",
       tokenLimit    => 1,
       hintText      => $c->maketext("teams.tokeninput.type"),
       noResultsText => encode_entities( $c->maketext("tokeninput.text.no-results") ),
@@ -794,7 +794,7 @@ sub edit :Chained("base") :PathPart("edit") :Args(0) {
   
   ## Team(s) captained
   $tokeninput_captain_options = {
-    jsonContainer => "json_teams",
+    jsonContainer => "json_search",
     hintText      => $c->maketext("teams.tokeninput.type-captain"),
     noResultsText => encode_entities( $c->maketext("tokeninput.text.no-results") ),
     searchingText => encode_entities( $c->maketext("tokeninput.text.searching") ),

--- a/lib/TopTable/Controller/Search.pm
+++ b/lib/TopTable/Controller/Search.pm
@@ -140,7 +140,7 @@ sub do_search {
       
       # Set up the stash
       $c->stash({
-        json_search => $json_search,
+        json_data => {json_search => $json_search},
         skip_view_online => 1,
       });
       

--- a/lib/TopTable/Controller/Users.pm
+++ b/lib/TopTable/Controller/Users.pm
@@ -1823,7 +1823,7 @@ sub check_authorisation :Private {
   my ( $self, $c, $actions, $message_detail, $redirect ) = @_;
   my ( @roles, @role_names ) = ();
   my ( $anonymous_permission, $authorised );
-  my $content_type = $c->request->parameters->{content_type} || "html";
+  #my $content_type = $c->request->parameters->{content_type} || "html";
   
   # If the action is an array, we need to check for each
   if ( ref( $actions ) eq "ARRAY" ) {
@@ -1875,7 +1875,7 @@ sub check_authorisation :Private {
       } else {
         # Logged in, just error
         if ( $redirect ) {
-          if ( $content_type eq "json" ) {
+          if ( $c->is_ajax ) {
             $c->detach( "TopTable::Controller::Root", "json_error", [403, $c->maketext("user.auth.denied", $message_detail)] );
           } else {
             $c->response->status(403);
@@ -1897,7 +1897,7 @@ sub check_authorisation :Private {
         
         # Redirect to the login page
         # Logged in, just error
-        if ( $content_type eq "json" ) {
+        if ( $c->is_ajax ) {
           $c->response->headers->header("WWW-Authenticate" => "FormBased");
           $c->detach( "TopTable::Controller::Root", "json_error", [401, $c->maketext("user.auth.login", $message_detail)] );
         } else {

--- a/lib/TopTable/Controller/Venues.pm
+++ b/lib/TopTable/Controller/Venues.pm
@@ -720,19 +720,19 @@ sub search_geolocation :Path("geolocation") {
     }
   }
   
-  if ( $content_type eq "json" ) {
+  if ( $c->is_ajax ) {
     # If it's an AJAX request, return a list so that the web app can display the options for selection
     $c->stash({
-      json_results      => \@results,
-      skip_view_online  => 1,
+      json_data => {
+        json_results => \@results,
+      },
+      skip_view_online => 1,
     });
     
     $c->detach( $c->view("JSON") );
   } else {
     # Not an AJAX request, just stash the first result
-    $c->stash({
-      geocode_results  => \@results,
-    });
+    $c->stash({geocode_results  => \@results});
   }
 }
 

--- a/lib/TopTable/Schema/Result/ClubTeamView.pm
+++ b/lib/TopTable/Schema/Result/ClubTeamView.pm
@@ -161,6 +161,7 @@ sub search_display {
   my ( $self, $params ) = @_;
   
   return {
+    id => $self->team_id,
     name => $self->team_with_club,
     url_keys => $self->url_keys,
     type => "team"

--- a/lib/TopTable/Schema/Result/User.pm
+++ b/lib/TopTable/Schema/Result/User.pm
@@ -777,7 +777,7 @@ sub approve {
   my ( $self, $params ) = @_;
   my $error = [];
   my $approver = delete $params->{approver};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   
   if ( ref( $approver ) eq "Catalyst::Authentication::Store::DBIx::Class::User" ) {
     # We have passed in the logged in user
@@ -812,7 +812,7 @@ sub reject {
   my ( $self, $params ) = @_;
   my $error = [];
   my $approver = delete $params->{approver};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   
   # We have passed in the logged in user
   # Update to approved

--- a/lib/TopTable/Schema/ResultSet/Club.pm
+++ b/lib/TopTable/Schema/ResultSet/Club.pm
@@ -49,7 +49,7 @@ sub search_by_name {
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/lib/TopTable/Schema/ResultSet/ClubTeamView.pm
+++ b/lib/TopTable/Schema/ResultSet/ClubTeamView.pm
@@ -17,7 +17,7 @@ sub search_by_name {
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/lib/TopTable/Schema/ResultSet/Division.pm
+++ b/lib/TopTable/Schema/ResultSet/Division.pm
@@ -16,7 +16,7 @@ sub search_by_name {
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   
@@ -308,7 +308,7 @@ Takes an arrayref of divisions, loops through and creates the new ones, checks t
 sub check_and_create {
   my ( $self, $parameters ) = @_;
   my $divisions = $parameters->{divisions} || [];
-  my $log       = $parameters->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $log       = $parameters->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $lang      = $parameters->{language} || sub { return wantarray ? @_ : "@_"; }; # Default to a sub that just returns everything, as we don't want errors if we haven't passed in a language sub.
   
   my $return          = {

--- a/lib/TopTable/Schema/ResultSet/FixturesGrid.pm
+++ b/lib/TopTable/Schema/ResultSet/FixturesGrid.pm
@@ -31,7 +31,7 @@ sub search_by_name {
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/lib/TopTable/Schema/ResultSet/Person.pm
+++ b/lib/TopTable/Schema/ResultSet/Person.pm
@@ -97,7 +97,7 @@ sub search_by_name {
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   
@@ -318,7 +318,7 @@ sub create_or_edit {
   my $fees_paid         = $parameters->{fees_paid};
   my $user              = $parameters->{user};
   my $season            = $parameters->{season};
-  my $log               = $parameters->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.    
+  my $log               = $parameters->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.    
   
   my ($dob_day, $dob_month, $dob_year)                            = split("/", $date_of_birth) if defined( $date_of_birth );
   my ($registration_day, $registration_month, $registration_year) = split("/", $registration_date) if defined( $registration_date );

--- a/lib/TopTable/Schema/ResultSet/SearchAllView.pm
+++ b/lib/TopTable/Schema/ResultSet/SearchAllView.pm
@@ -18,7 +18,7 @@ sub search_by_name {
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
   my $include_types = delete $params->{include_types};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/lib/TopTable/Schema/ResultSet/Season.pm
+++ b/lib/TopTable/Schema/ResultSet/Season.pm
@@ -78,7 +78,7 @@ sub search_by_name {
   my ( $self, $params ) = @_;
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/lib/TopTable/Schema/ResultSet/Team.pm
+++ b/lib/TopTable/Schema/ResultSet/Team.pm
@@ -242,7 +242,7 @@ sub search_by_name {
   my ( $self, $params ) = @_;
   my $q = delete $params->{q};
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.;
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.;
   
   # Construct the LIKE '%word1%' AND  LIKE '%word2%' etc.  I couldn't work out how to map this, so a loop it is.
   my @words = split( /\s+/, $q );

--- a/lib/TopTable/Schema/ResultSet/TeamMatchView.pm
+++ b/lib/TopTable/Schema/ResultSet/TeamMatchView.pm
@@ -17,7 +17,7 @@ sub search_by_name {
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/lib/TopTable/Schema/ResultSet/TemplateLeagueTableRanking.pm
+++ b/lib/TopTable/Schema/ResultSet/TemplateLeagueTableRanking.pm
@@ -31,7 +31,7 @@ sub search_by_name {
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/lib/TopTable/Schema/ResultSet/TemplateMatchIndividual.pm
+++ b/lib/TopTable/Schema/ResultSet/TemplateMatchIndividual.pm
@@ -32,7 +32,7 @@ sub search_by_name {
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/lib/TopTable/Schema/ResultSet/TemplateMatchTeam.pm
+++ b/lib/TopTable/Schema/ResultSet/TemplateMatchTeam.pm
@@ -31,7 +31,7 @@ sub search_by_name {
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
   my $season = delete $params->{season};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/lib/TopTable/Schema/ResultSet/User.pm
+++ b/lib/TopTable/Schema/ResultSet/User.pm
@@ -21,7 +21,7 @@ sub search_by_name {
   my ( $self, $params ) = @_;
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   
@@ -260,7 +260,7 @@ sub create_or_edit {
   my $activation_expiry_limit = delete $params->{activation_expiry_limit} || 24;
   my $manual_approval = delete $params->{manual_approval};
   my $installed_languages = delete $params->{installed_languages};
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $set_locale;
   my $response = {error => [], warning => []};
   my $can_edit_roles = 0;

--- a/lib/TopTable/Schema/ResultSet/Venue.pm
+++ b/lib/TopTable/Schema/ResultSet/Venue.pm
@@ -52,7 +52,7 @@ sub search_by_name {
   my ( $self, $params ) = @_;
   my $q = delete $params->{q};
   my $split_words = delete $params->{split_words} || 0;
-  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $page = delete $params->{page} || undef;
   my $results_per_page = delete $params->{results} || undef;
   

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -4700,6 +4700,9 @@ msgstr "Page %1 does not exist."
 msgid "system-event-log.heading.user"
 msgstr "User"
 
+msgid "system-event-log.guest"
+msgstr "Guest"
+
 msgid "system-event-log.heading.ip-address"
 msgstr "IP address"
 

--- a/root/static/script/standard/datatable-clear-pipeline.js
+++ b/root/static/script/standard/datatable-clear-pipeline.js
@@ -1,0 +1,115 @@
+/**
+ *  Pipelining function for DataTables. To be used to the `ajax` option of DataTables
+ *
+ */
+ 
+$.fn.dataTable.pipeline = function ( opts ) {
+  // Configuration options
+  var conf = $.extend({
+    pages: 5,     // number of pages to cache
+    url: "",      // script url
+    data: null,   // function or object with parameters to send to the server matching how `ajax.data` works in DataTables
+    method: "GET" // Ajax HTTP method
+  }, opts );
+
+  // Private variables for storing the cache
+  var cacheLower = -1;
+  var cacheUpper = null;
+  var cacheLastRequest = null;
+  var cacheLastJson = null;
+
+  return function ( request, drawCallback, settings ) {
+    var ajax = false;
+    var requestStart = request.start;
+    var drawStart = request.start;
+    var requestLength = request.length;
+    var requestEnd = requestStart + requestLength;
+     
+    if ( settings.clearCache ) {
+      // API requested that the cache be cleared
+      ajax = true;
+      settings.clearCache = false;
+    } else if ( cacheLower < 0 || requestStart < cacheLower || requestEnd > cacheUpper ) {
+      // outside cached data - need to make a request
+      ajax = true;
+    } else if ( JSON.stringify( request.order )   !== JSON.stringify( cacheLastRequest.order ) ||
+              JSON.stringify( request.columns ) !== JSON.stringify( cacheLastRequest.columns ) ||
+              JSON.stringify( request.search )  !== JSON.stringify( cacheLastRequest.search )
+    ) {
+      // properties changed (ordering, columns, searching)
+      ajax = true;
+    }
+     
+    // Store the request for checking next time around
+    cacheLastRequest = $.extend( true, {}, request );
+
+    if ( ajax ) {
+      // Need data from the server
+      if ( requestStart < cacheLower ) {
+        requestStart = requestStart - (requestLength*(conf.pages-1));
+
+        if ( requestStart < 0 ) {
+          requestStart = 0;
+        }
+      }
+       
+      cacheLower = requestStart;
+      cacheUpper = requestStart + (requestLength * conf.pages);
+
+      request.start = requestStart;
+      request.length = requestLength*conf.pages;
+      request.pages = conf.pages;
+      request.pagelength = requestLength;
+
+      // Provide the same `data` options as DataTables.
+      if ( typeof conf.data === "function" ) {
+        // As a function it is executed with the data object as an arg
+        // for manipulation. If an object is returned, it is used as the
+        // data object to submit
+        var d = conf.data( request );
+        if ( d ) {
+          $.extend( request, d );
+        }
+      } else if ( $.isPlainObject( conf.data ) ) {
+        // As an object, the data given extends the default
+        $.extend( request, conf.data );
+      }
+
+      return $.ajax({
+        "type":     conf.method,
+        "url":      conf.url,
+        "data":     request,
+        "dataType": "json",
+        "cache":    false,
+        "success":  function ( json ) {
+          cacheLastJson = $.extend(true, {}, json);
+
+          if ( cacheLower != drawStart ) {
+            json.data.splice( 0, drawStart-cacheLower );
+          }
+          
+          if ( requestLength >= -1 ) {
+            json.data.splice( requestLength, json.data.length );
+          }
+           
+          drawCallback( json );
+        }
+      });
+    } else {
+      json = $.extend( true, {}, cacheLastJson );
+      json.draw = request.draw; // Update the echo for each response
+      json.data.splice( 0, requestStart-cacheLower );
+      json.data.splice( requestLength, json.data.length );
+      
+      drawCallback(json);
+    }
+  }
+};
+ 
+// Register an API method that will empty the pipelined data, forcing an Ajax
+// fetch on the next draw (i.e. `table.clearPipeline().draw()`)
+$.fn.dataTable.Api.register( "clearPipeline()", function () {
+  return this.iterator( "table", function ( settings ) {
+    settings.clearCache = true;
+  });
+});

--- a/root/templates/html/event-viewer/view-ajax.ttkt
+++ b/root/templates/html/event-viewer/view-ajax.ttkt
@@ -1,0 +1,27 @@
+[% # This is a TT comment. -%]
+
+[% # Note That the '-' at the beginning or end of TT code  -%]
+[% # "chomps" the whitespace/newline at that end of the    -%]
+[% # output (use View Source in browser to see the effect) -%]
+
+<table id="event-log" class="stripe hover order-column row-border" style="width: 100%;">
+  <thead>
+    <tr>
+[%
+    UNLESS exclude_event_user;
+-%]
+      <th class="event-user">[% c.maketext("system-event-log.heading.user") %]</th>
+[%
+      IF authorisation.view_users_ip;
+-%]
+      <th class="event-ip">[% c.maketext("system-event-log.heading.ip-address") %]</th>
+[%
+      END;
+    END;
+-%]
+      <th class="event-datetime">[% c.maketext("system-event-log.heading.timestamp") %]</th>
+      <th class="event-type">[% c.maketext("system-event-log.heading.category") %]</th>
+      <th class="event-detail">[% c.maketext("system-event-log.heading.description") %]</th>
+    </tr>
+  </thead>
+</table>

--- a/root/templates/html/event-viewer/view-preloaded.ttkt
+++ b/root/templates/html/event-viewer/view-preloaded.ttkt
@@ -4,14 +4,6 @@
 [% # "chomps" the whitespace/newline at that end of the    -%]
 [% # output (use View Source in browser to see the effect) -%]
 
-[%
-# Pagination
-IF event_logs.count;
-  # Use PROCESS instead of INCLUDE so that the page_links_text is defined in the current template thereafter
-  PROCESS "html/generic/pagination.ttkt" CONTROLLER = "event-log", OBJECT_PLURAL = "events";
-  page_links_text;
--%]
-
 <table id="datatable" class="stripe hover order-column row-border" style="width: 100%;">
   <thead>
     <tr>
@@ -35,7 +27,7 @@ IF event_logs.count;
   </thead>
   <tbody>
 [%
-  WHILE (event = event_logs.next);
+  FOREACH event IN events;
     # Work out what object type we have
     SET object = "system_event_log_" _ event.object_type _ "s";
     SET display_description = event.display_description(3, 35);
@@ -121,13 +113,4 @@ IF event_logs.count;
 -%]
   </tbody>
 </table>
-[%
-page_links_text;
-ELSE;
--%]
-<div class="list-item">
-  No events to display.
-</div>
-[%
-END;
--%]
+

--- a/root/templates/html/index.ttkt
+++ b/root/templates/html/index.ttkt
@@ -6,9 +6,9 @@
 [%
 # Recent updates
 SET table_width = 70;
-INCLUDE "html/event-log/list.ttkt";
+INCLUDE "html/event-viewer/view-preloaded.ttkt";
 -%]<br />
-<a href="[% c.uri_for("/event-log") %]">[% c.maketext("home-page.updates.view-more") %]</a><br /><br />
+<a href="[% c.uri_for("/event-viewer") %]">[% c.maketext("home-page.updates.view-more") %]</a><br /><br />
 <div class="row">
   <div class="column left">
   <h4>[% c.maketext("home-page.news.recent") %]</h4>

--- a/root/templates/scripts/event-viewer/view.ttkt
+++ b/root/templates/scripts/event-viewer/view.ttkt
@@ -1,0 +1,93 @@
+  /**
+   *  Initialise datatable
+   *
+   */
+  var table = $("#event-log").DataTable({
+    "responsive": true,
+    "paging": true,
+    "info": true,
+    "pageLength": 25,
+    "lengthChange": true,
+    "lengthMenu": [ [10, 25, 50, 100, 200], [10, 25, 50, 100, 200] ],
+    "info": true,
+    "processing": true,
+    "deferRender": true,
+    "serverSide": true,
+    "search": {
+      "return": true
+    },
+    "ajax": $.fn.dataTable.pipeline({
+      url: "[% c.uri_for_action("/event-viewer/load_events_js") %]",
+      pages: [% c.config.Tables.pages_to_retrieve OR 5 %] // number of pages to cache
+    }),
+[%
+IF authorisation.view_users_ip;
+-%]
+    "order": [[2, "desc"]],
+    "columns": [{
+      "responsivePriority": 3,
+      "name": "user.username"
+    }, {
+      "responsivePriority": 5,
+      "type": "ip-address",
+      "name": "ip_address"
+    }, {
+      "responsivePriority": 1,
+      "name": "me.log_updated"
+    }, {
+      "responsivePriority": 4,
+      "name": "system_event_log_type.object_description"
+    }, {
+      "responsivePriority": 2,
+      "name": "description",
+      "orderable": false
+    }]
+[%
+ELSE;
+-%]
+    "order": [[1, "desc"]],
+    "columns": [{
+      "responsivePriority": 3,
+      "name": "user.username"
+    }, {
+      "responsivePriority": 1,
+      "name": "me.log_updated"
+    }, {
+      "responsivePriority": 4,
+      "name": "system_event_log_type.object_description"
+    }, {
+      "responsivePriority": 2,
+      "name": "description",
+      "orderable": false
+    }]
+[%
+END;
+-%]
+  });
+  
+  table.on("draw", function() {
+    $(".tip").qtip({
+    style: {
+      //classes: "qtip-plain qtip-shadow qtip-rounded",
+      classes: "qtip-tipsy"
+    },
+    show: {
+      delay: 600,
+      solo: true
+    },
+    hide: {
+      fixed: true,
+      delay: 200
+    },
+    position: {
+      my: "top center",
+      at: "bottom center",
+    }
+    });
+  });
+  
+  $("select[name=event-log_length]").chosen({
+    disable_search: true,
+    single_backstroke_delete: false,
+    allow_single_deselect: true
+  });


### PR DESCRIPTION
* [New] Event log namespace has changed from /event-log to /event-viewer.  This is because having /event-log in a JS include seems to trigger some ad blockers.
* [New] Event log table is now server-side processed, including search.  Because the descriptions are generated from category settings and language packs, this *can't* be searched, therefore the search function is for username, IP address (if viewed), etc.  This has meant some breaking changes to SystemEventLog resultset method 'page_records'.
* [New] Changed event view grab for home page to cope with new changes to page_records function in the SystemEventLog resultset.
* [New] JSON view expose_stash setting changed to "json_data".  This means some areas have changed to put their settings inside json_data so it can be returned.
* [Fix] Default logging routines in some result / resultset classes didn't add a newline in the printf function.