### PR TITLE
2024 2025 rule changes

### DIFF
--- a/lib/TopTable/Controller/Seasons.pm
+++ b/lib/TopTable/Controller/Seasons.pm
@@ -604,8 +604,8 @@ Take the entered season / division data from the create / edit form and put them
 sub process_form :Private {
   my ( $self, $c, $action ) = @_;
   my $season = $c->stash->{season};
-  my @field_names = qw( name start_hour start_minute timezone allow_loan_players allow_loan_players_above allow_loan_players_below allow_loan_players_across allow_loan_players_same_club_only allow_loan_players_multiple_teams_per_division loan_players_limit_per_player loan_players_limit_per_player_per_team loan_players_limit_per_player_per_opposition loan_players_limit_per_team rules );
-  my @processed_field_names = qw( name start_date end_date start_hour start_minute timezone allow_loan_players allow_loan_players_above allow_loan_players_below allow_loan_players_across allow_loan_players_same_club_only allow_loan_players_multiple_teams_per_division loan_players_limit_per_player loan_players_limit_per_player_per_team loan_players_limit_per_player_per_opposition loan_players_limit_per_team rules );
+  my @field_names = qw( name start_hour start_minute timezone allow_loan_players allow_loan_players_above allow_loan_players_below allow_loan_players_across allow_loan_players_same_club_only allow_loan_players_multiple_teams_per_division loan_players_limit_per_player loan_players_limit_per_player_per_team loan_players_limit_per_player_per_opposition loan_players_limit_per_team void_unplayed_games_if_both_teams_incomplete forefeit_count_averages_if_game_not_started missing_player_count_win_in_averages rules );
+  my @processed_field_names = qw( name start_date end_date start_hour start_minute timezone allow_loan_players allow_loan_players_above allow_loan_players_below allow_loan_players_across allow_loan_players_same_club_only allow_loan_players_multiple_teams_per_division loan_players_limit_per_player loan_players_limit_per_player_per_team loan_players_limit_per_player_per_opposition loan_players_limit_per_team void_unplayed_games_if_both_teams_incomplete forefeit_count_averages_if_game_not_started missing_player_count_win_in_averages rules );
   
   # Build the divisions array expected by the create / edit routine
   my @divisions = ();

--- a/lib/TopTable/Schema/Result/Season.pm
+++ b/lib/TopTable/Schema/Result/Season.pm
@@ -152,6 +152,26 @@ __PACKAGE__->table("seasons");
   extra: {unsigned => 1}
   is_nullable: 0
 
+=head2 void_unplayed_games_if_both_teams_incomplete
+
+  data_type: 'tinyint'
+  default_value: 0
+  is_nullable: 0
+
+Void games (no team wins) between a present and absent player if both teams have missing players
+
+=head2 forefeit_count_averages_if_game_not_started
+
+  data_type: 'tinyint'
+  default_value: 0
+  is_nullable: 0
+
+=head2 missing_player_count_win_in_averages
+
+  data_type: 'tinyint'
+  default_value: 0
+  is_nullable: 0
+
 =head2 rules
 
   data_type: 'longtext'
@@ -239,6 +259,12 @@ __PACKAGE__->add_columns(
     extra => { unsigned => 1 },
     is_nullable => 0,
   },
+  "void_unplayed_games_if_both_teams_incomplete",
+  { data_type => "tinyint", default_value => 0, is_nullable => 0 },
+  "forefeit_count_averages_if_game_not_started",
+  { data_type => "tinyint", default_value => 0, is_nullable => 0 },
+  "missing_player_count_win_in_averages",
+  { data_type => "tinyint", default_value => 0, is_nullable => 0 },
   "rules",
   { data_type => "longtext", is_nullable => 1 },
 );
@@ -437,8 +463,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2022-08-21 20:10:49
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0PRlHrO8usMaNYn3gwM8Fw
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-05-05 09:17:30
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:TXqdS4cnZSi+VdBwbEPKoA
 
 use HTML::Entities;
 

--- a/lib/TopTable/Schema/Result/TeamMatch.pm
+++ b/lib/TopTable/Schema/Result/TeamMatch.pm
@@ -962,6 +962,28 @@ sub players_absent {
   return $self->search_related("team_match_players", {player_missing => 1})->count;
 }
 
+=head2 home_players_absent
+
+Returns the number of home players missing from the match.
+
+=cut
+
+sub home_players_absent {
+  my ( $self ) = @_;
+  return $self->search_related("team_match_players", {player_missing => 1, location => "home"})->count;
+}
+
+=head2 away_players_absent
+
+Returns the number of home players missing from the match.
+
+=cut
+
+sub away_players_absent {
+  my ( $self ) = @_;
+  return $self->search_related("team_match_players", {player_missing => 1, location => "away"})->count;
+}
+
 =head2 games_reordered
 
 Checks whether any 'actual_game_number' fields in games for this match differ from the 'scheduled_game_number' - if so, returns 1, else 0.

--- a/lib/TopTable/Schema/Result/TeamMatchPlayer.pm
+++ b/lib/TopTable/Schema/Result/TeamMatchPlayer.pm
@@ -459,6 +459,7 @@ sub update_person {
   my $person = $params->{person};
   my $location = $self->location->id;
   my $match = $self->team_match;
+  my $season = $match->season;
   my ( $active_season, $loan_team );
   my $originally_missing = 0;
   my $game_scores_deleted = 0;
@@ -529,7 +530,6 @@ sub update_person {
         # Check it's active to be safe
         if ( $loan_player ) {
           # Grab the loan player rules
-          my $season = $match->season;
           my $match_division = $match->division_season->division;
           my $enc_match_division = encode_entities($match_division->name);
           

--- a/lib/TopTable/Schema/ResultSet/Division.pm
+++ b/lib/TopTable/Schema/ResultSet/Division.pm
@@ -154,7 +154,7 @@ sub all_divisions {
       prefetch => {
         division_seasons => {fixtures_grid => "fixtures_grid_weeks"},
       },
-      order_by => {-asc => qw( rank )},
+      order_by => {-asc => qw( me.rank )},
     };
   } else {
     $where = {};
@@ -162,7 +162,7 @@ sub all_divisions {
       prefetch => {
         division_seasons => {fixtures_grid => "fixtures_grid_weeks"},
       },
-      order_by => {-asc => qw( rank )}
+      order_by => {-asc => qw( me.rank )}
     };
   }
   

--- a/lib/TopTable/Schema/ResultSet/DivisionSeason.pm
+++ b/lib/TopTable/Schema/ResultSet/DivisionSeason.pm
@@ -25,7 +25,7 @@ sub divisions_and_teams_in_season_by_grid_position {
       }]
     }],
     order_by  => {
-      -asc => [ qw( rank team_seasons.grid_position ) ]
+      -asc => [ qw( division.rank team_seasons.grid_position ) ]
     }
   });
 }

--- a/lib/TopTable/Schema/ResultSet/Official.pm
+++ b/lib/TopTable/Schema/ResultSet/Official.pm
@@ -151,7 +151,7 @@ sub create_or_edit {
   # Setup schema / logging
   my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $locale = delete $params->{locale} || "en_GB"; # Usually handled by the app, other clients (i.e., for cmdline testing) can pass it in.
-  $logger->("debug", sprintf("Locale: '%s'", $locale));
+  #$logger->("debug", sprintf("Locale: '%s'", $locale));
   my $schema = $self->result_source->schema;
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
@@ -247,7 +247,7 @@ sub create_or_edit {
   if ( scalar(@{$holders}) ) {
     # We have holders, check them
     foreach my $holder ( @{$holders} ) {
-      $logger->("debug", sprintf("holder: %s, ref: %s", $holder, ref($holder)));
+      #$logger->("debug", sprintf("holder: %s, ref: %s", $holder, ref($holder)));
       if ( defined($holder) and ref($holder) eq "TopTable::Model::DB::Person" ) {
         
         # Person is valid, add them if we haven't seen them before
@@ -374,7 +374,7 @@ sub reorder {
   # Setup schema / logging
   my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $locale = delete $params->{locale} || "en_GB"; # Usually handled by the app, other clients (i.e., for cmdline testing) can pass it in.
-  $logger->("debug", sprintf("Locale: '%s'", $locale));
+  #$logger->("debug", sprintf("Locale: '%s'", $locale));
   my $schema = $self->result_source->schema;
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;

--- a/lib/TopTable/Schema/ResultSet/Season.pm
+++ b/lib/TopTable/Schema/ResultSet/Season.pm
@@ -362,6 +362,9 @@ sub create_or_edit {
   my $loan_players_limit_per_player_per_team = $params->{loan_players_limit_per_player_per_team} || 0;
   my $loan_players_limit_per_player_per_opposition = $params->{loan_players_limit_per_player_per_opposition} || 0;
   my $loan_players_limit_per_team = $params->{loan_players_limit_per_team} || 0;
+  my $void_unplayed_games_if_both_teams_incomplete = $params->{void_unplayed_games_if_both_teams_incomplete} || 0;
+  my $forefeit_count_averages_if_game_not_started = $params->{forefeit_count_averages_if_game_not_started} || 0;
+  my $missing_player_count_win_in_averages = $params->{missing_player_count_win_in_averages} || 0;
   my $rules = $params->{rules} || undef;
   my $divisions = $params->{divisions} // [];
   my $response = {
@@ -571,6 +574,11 @@ sub create_or_edit {
       $loan_players_limit_per_team = 0;
     }
     
+    # Rules covering unplayed games / missing players
+    $void_unplayed_games_if_both_teams_incomplete = $void_unplayed_games_if_both_teams_incomplete ? 1 : 0;
+    $forefeit_count_averages_if_game_not_started = $forefeit_count_averages_if_game_not_started ? 1 : 0;
+    $missing_player_count_win_in_averages = $missing_player_count_win_in_averages ? 1 : 0;
+    
     $response->{fields}{allow_loan_players} = $allow_loan_players;
     $response->{fields}{allow_loan_players_above} = $allow_loan_players_above;
     $response->{fields}{allow_loan_players_below} = $allow_loan_players_below;
@@ -581,6 +589,9 @@ sub create_or_edit {
     $response->{fields}{loan_players_limit_per_player_per_team} = $loan_players_limit_per_player_per_team;
     $response->{fields}{loan_players_limit_per_player_per_opposition} = $loan_players_limit_per_player_per_opposition;
     $response->{fields}{loan_players_limit_per_team} = $loan_players_limit_per_team;
+    $response->{fields}{void_unplayed_games_if_both_teams_incomplete} = $void_unplayed_games_if_both_teams_incomplete;
+    $response->{fields}{forefeit_count_averages_if_game_not_started} = $forefeit_count_averages_if_game_not_started;
+    $response->{fields}{missing_player_count_win_in_averages} = $missing_player_count_win_in_averages;
   }
   
   # Filter the HTML from the rules
@@ -624,6 +635,9 @@ sub create_or_edit {
         loan_players_limit_per_player_per_team => $loan_players_limit_per_player_per_team,
         loan_players_limit_per_player_per_opposition => $loan_players_limit_per_player_per_opposition,
         loan_players_limit_per_team => $loan_players_limit_per_team,
+        void_unplayed_games_if_both_teams_incomplete => $void_unplayed_games_if_both_teams_incomplete,
+        forefeit_count_averages_if_game_not_started => $forefeit_count_averages_if_game_not_started,
+        missing_player_count_win_in_averages => $missing_player_count_win_in_averages,
         fixtures_weeks => \@fixtures_weeks,
         rules => $rules,
       });
@@ -656,6 +670,9 @@ sub create_or_edit {
           loan_players_limit_per_player_per_team => $loan_players_limit_per_player_per_team,
           loan_players_limit_per_player_per_opposition => $loan_players_limit_per_player_per_opposition,
           loan_players_limit_per_team => $loan_players_limit_per_team,
+          void_unplayed_games_if_both_teams_incomplete => $void_unplayed_games_if_both_teams_incomplete,
+          forefeit_count_averages_if_game_not_started => $forefeit_count_averages_if_game_not_started,
+          missing_player_count_win_in_averages => $missing_player_count_win_in_averages,
           rules => $rules,
         };
       }

--- a/lib/TopTable/Schema/ResultSet/TemplateMatchIndividual.pm
+++ b/lib/TopTable/Schema/ResultSet/TemplateMatchIndividual.pm
@@ -260,11 +260,11 @@ sub create_or_edit {
   
   # Check the game type has been selected and is valid
   if ( defined($game_type) ) {
-    $logger->("debug", sprintf("game type: %s, ref: %s", $game_type, ref($game_type)));
+    #$logger->("debug", sprintf("game type: %s, ref: %s", $game_type, ref($game_type)));
     if ( ref($game_type) ne "TopTable::Model::DB::LookupGameType" ) {
       # If we haven't got a valid object, try and look it up assuming an ID
       $game_type = $schema->resultset("LookupGameType")->find($game_type);
-      $logger->("debug", sprintf("game type post-lookup: %s, ref: %s", $game_type, ref($game_type)));
+      #$logger->("debug", sprintf("game type post-lookup: %s, ref: %s", $game_type, ref($game_type)));
     }
     
     # Definitely an error if we don't have a value now now

--- a/lib/TopTable/Schema/ResultSet/Venue.pm
+++ b/lib/TopTable/Schema/ResultSet/Venue.pm
@@ -246,7 +246,7 @@ sub create_or_edit {
     completed => 0,
   };
   
-  $logger->("debug", sprintf("Active: %s (defined: %s)", $active, defined($active)));
+  #$logger->("debug", sprintf("Active: %s (defined: %s)", $active, defined($active)));
   
   if ( $action ne "create" and $action ne "edit" ) {
     # Invalid action passed
@@ -273,7 +273,7 @@ sub create_or_edit {
     
     # Will always be active unless we can deactivate it.
     $active = 1 unless $venue->can_deactivate;
-    $logger->("debug", "Can't be deactivated, setting active to 1") unless $venue->can_deactivate;
+    #$logger->("debug", "Can't be deactivated, setting active to 1") unless $venue->can_deactivate;
   }
   
   # Error checking
@@ -326,11 +326,11 @@ sub create_or_edit {
   
   # Active - must be 1 or 0
   if ( defined($active) ) {
-    $logger->("debug", sprintf("Active is defined, doing sanity check for 1 or 0: %s", $active));
+    #$logger->("debug", sprintf("Active is defined, doing sanity check for 1 or 0: %s", $active));
     $active = $active ? 1 : 0;
   } else {
     $active = 0;
-    $logger->("debug", sprintf("Active is not defined, setting to 0: %s", $active));
+    #$logger->("debug", sprintf("Active is not defined, setting to 0: %s", $active));
   }
   
   if ( scalar @{$response->{errors}} == 0 ) {

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -1684,6 +1684,9 @@ msgstr "Timezone"
 msgid "seasons.form.legend.loan-players"
 msgstr "Loan players"
 
+msgid "seasons.form.legend.rules-when-games-not-completed"
+msgstr "What to do when games can&#39;t be completed"
+
 msgid "seasons.form.field.allow-loan-players"
 msgstr "Allow loan players"
 
@@ -1713,6 +1716,18 @@ msgstr "Maximum number of times a player may play on loan <i><u><b>for</b></u></
 
 msgid "seasons.form.field.loan-players-limit-per-opposition"
 msgstr "Maximum number of times a player may play on loan <i><u><b>against</b></u></i> the same team"
+
+msgid "seasons.form.legend.rules-when-games-not-completed"
+msgstr "What to do when games can&#39;t be completed"
+
+msgid "seasons.form.field.void-unplayed-games-if-both-teams-incomplete"
+msgstr "Void unplayed games if both teams have missing players (no team wins a voided game)"
+
+msgid "seasons.form.field.forefeit-count-averages-if-game-not-started"
+msgstr "Count a forefeited game in the averages, even if it wasn&#39;t started"
+
+msgid "seasons.form.field.seasons.form.field.missing-player-count-win-in-averages"
+msgstr "Count an unplayed game due to a missing player as a win in the averages for the other player (not relevant if both teams have players missing and the void games setting is in effect)."
 
 msgid "seasons.form.rules"
 msgstr "Rules"

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -1691,19 +1691,19 @@ msgid "seasons.form.field.allow-loan-players"
 msgstr "Allow loan players"
 
 msgid "seasons.form.field.allow-loan-players-from-lower"
-msgstr "From divisions below"
+msgstr "Allow loan players from divisions below"
 
 msgid "seasons.form.field.allow-loan-players-from-higher"
-msgstr "From divisions above"
+msgstr "Allow loan players from divisions above"
 
 msgid "seasons.form.field.allow-loan-players-from-same-level"
-msgstr "From the same level"
+msgstr "Allow loan players from the same division"
 
 msgid "seasons.form.field.loan-players-from-same-club-only"
-msgstr "Must play for the same club"
+msgstr "Loan players must play for the same club"
 
 msgid "seasons.form.field.allow-loan-players-multiple-teams-per-division"
-msgstr "Can play for multiple teams in the same division"
+msgstr "Allow loan players to play for more than one team in the same division"
 
 msgid "seasons.form.loan-players.limits-message"
 msgstr "For the fields below, 0 or blank means &#39;no limit&#39;."
@@ -1717,17 +1717,29 @@ msgstr "Maximum number of times a player may play on loan <i><u><b>for</b></u></
 msgid "seasons.form.field.loan-players-limit-per-opposition"
 msgstr "Maximum number of times a player may play on loan <i><u><b>against</b></u></i> the same team"
 
+msgid "seasons.allowed-yes"
+msgstr "Yes"
+
+msgid "seasons.allowed-no"
+msgstr "No"
+
+msgid "seasons.loan-players.no-limit"
+msgstr "No limit"
+
+msgid "seasons.award-forefeit-rules"
+msgstr "Award &amp; forefeit rules"
+
 msgid "seasons.form.legend.rules-when-games-not-completed"
 msgstr "What to do when games can&#39;t be completed"
 
 msgid "seasons.form.field.void-unplayed-games-if-both-teams-incomplete"
-msgstr "Void unplayed games if both teams have missing players (no team wins a voided game)"
+msgstr "Void unplayed games if both teams have missing players"
 
 msgid "seasons.form.field.forefeit-count-averages-if-game-not-started"
 msgstr "Count a forefeited game in the averages, even if it wasn&#39;t started"
 
 msgid "seasons.form.field.seasons.form.field.missing-player-count-win-in-averages"
-msgstr "Count an unplayed game due to a missing player as a win in the averages for the other player (not relevant if both teams have players missing and the void games setting is in effect)."
+msgstr "Count an unplayed game due to a missing player as a win in the averages for the other player (not relevant if both teams have players missing and the void games setting is in effect)"
 
 msgid "seasons.form.rules"
 msgstr "Rules"
@@ -1947,6 +1959,9 @@ msgstr "Matches with players missing"
 
 msgid "seasons.statistics.matches-with-loan-players"
 msgstr "Matches using at least one loan player"
+
+msgid "seasons.loan-player-rules"
+msgstr "Loan player rules"
 
 msgid "seasons.view.dates"
 msgstr "Dates"
@@ -2568,7 +2583,7 @@ msgid "matches.add-player.error.person-invalid"
 msgstr "The person specified to add to this position is invalid."
 
 msgid "matches.add-player.error.update-game-failed"
-msgstr "Failed to update game %1 in the team match games table."
+msgstr "Failed to update game %1 in the team match games table: %2."
 
 msgid "matches.add-player.error.update-failed"
 msgstr "Failed to update player; please refresh the page and try again.  If the error persists, please contact the system administrator."
@@ -2801,44 +2816,59 @@ msgstr "<a href=\"%3\">%1</a> <span class=\"game-result\">drew with</span> <a hr
 msgid "matches.game.result.doubles-draw"
 msgstr "<a href=\"%5\">%1</a> &amp; <a href=\"%6\">%2</a> <span class=\"game-result\">drew with</span> <a href=\"%7\">%3</a> &amp; <a href=\"%8\">%4</a>"
 
-msgid "matches.game.result.both-players-missing"
-msgstr "This game was not played because both the home and away players were absent."
+msgid "matches.game.score.both-players-missing"
+msgstr "Void because both the home and away players were absent"
+
+msgid "matches.game.score.home-player-missing"
+msgstr "Home player absent"
 
 msgid "matches.game.result.home-player-missing"
-msgstr "This game was not played because the home player was absent."
+msgstr "Absent player <span class="game-result">v</span> <a href="%2">%1</a>"
+
+msgid "matches.game.score.home-player-missing-void"
+msgstr "Void because the home player was absent and the away team also have absent players"
+
+msgid "matches.game.score.away-player-missing"
+msgstr "Away player absent"
 
 msgid "matches.game.result.away-player-missing"
-msgstr "This game was not played because the away player was absent."
+msgstr "<a href="%2">%1</a> <span class="game-result">v</span> absent player"
+
+msgid "matches.game.score.away-player-missing-void"
+msgstr "Void because the away player was absent and the home team also have absent players"
+
+msgid "matches.game.result.void"
+msgstr "Void"
 
 msgid "matches.game.result.home-singles-player-forefeited"
-msgstr "not played because the home player pulled out."
-#msgstr "<a href=\"%3\"%5>%1</a> <span class=\"game-result\">v</span> <a href=\"%4\"%6>%2</a>: not played because the home player pulled out."
+msgstr "not played because the home player pulled out"
+#msgstr "<a href=\"%3\"%5>%1</a> <span class=\"game-result\">v</span> <a href=\"%4\"%6>%2</a>: not played because the home player pulled out"
 
 msgid "matches.game.result.away-singles-player-forefeited"
 msgstr "not played because the away player pulled out."
-#msgstr "<a href=\"%3\"%5>%1</a> <span class=\"game-result\">v</span> <a href=\"%4\"%6>%2</a>: not played because the away player pulled out."
+#msgstr "<a href=\"%3\"%5>%1</a> <span class=\"game-result\">v</span> <a href=\"%4\"%6>%2</a>: not played because the away player pulled out"
 
 msgid "matches.game.result.home-singles-player-retired"
 msgstr "finished early because the home player retired."
-#msgstr "<a href=\"%3\"%5>%1</a> <span class=\"game-result\">v</span> <a href=\"%4\"%6>%2</a>: finished early because the home player retired."
+#msgstr "<a href=\"%3\"%5>%1</a> <span class=\"game-result\">v</span> <a href=\"%4\"%6>%2</a>: finished early because the home player retired"
 
 msgid "matches.game.result.away-singles-player-retired"
 msgstr "finished early because the away player retired."
-#msgstr "<a href=\"%3\"%5>%1</a> <span class=\"game-result\">v</span> <a href=\"%4\"%6>%2</a>: finished early because the away player retired."
+#msgstr "<a href=\"%3\"%5>%1</a> <span class=\"game-result\">v</span> <a href=\"%4\"%6>%2</a>: finished early because the away player retired"
 
 msgid "matches.game.result.home-doubles-player-forefeited"
-msgstr "This game was not played because the home team pulled out."
+msgstr "This game was not played because the home team pulled out"
 
 msgid "matches.game.result.away-doubles-player-forefeited"
-msgstr "This game was not played because the away team pulled out."
+msgstr "This game was not played because the away team pulled out"
 
 msgid "matches.game.result.home-doubles-player-retired"
-msgstr "finished early because the home team retired."
-#msgstr "<a href=\"%5\">%1</a> &amp; <a href=\"%6\">%2</a> <span class=\"game-result\">v</span> <a href=\"%7\">%3</a> &amp; <a href=\"%8\">%4</a>: finished early because the home team retired."
+msgstr "finished early because the home team retired"
+#msgstr "<a href=\"%5\">%1</a> &amp; <a href=\"%6\">%2</a> <span class=\"game-result\">v</span> <a href=\"%7\">%3</a> &amp; <a href=\"%8\">%4</a>: finished early because the home team retired"
 
 msgid "matches.game.result.away-doubles-player-retired"
 msgstr "finished early because the away team retired."
-#msgstr "<a href=\"%5\">%1</a> &amp; <a href=\"%6\">%2</a> <span class=\"game-result\">v</span> <a href=\"%7\">%3</a> &amp; <a href=\"%8\">%4</a>: finished early because the away team retired."
+#msgstr "<a href=\"%5\">%1</a> &amp; <a href=\"%6\">%2</a> <span class=\"game-result\">v</span> <a href=\"%7\">%3</a> &amp; <a href=\"%8\">%4</a>: finished early because the away team retired"
 
 msgid "matches.result.win"
 msgstr "Win"
@@ -4511,7 +4541,7 @@ msgid "user.login.error.authentication-failed"
 msgstr "The username or password is incorrect; please try again."
 
 msgid "user.login.error.user-not-activated"
-msgstr "The username entered has not yet been activated; please check the username, or if this is the correct account, you can <a href=\"%1\">resend the activation email</a>."
+msgstr "The username entered has not yet been activated; please check the username, or if this is the correct account, you can <a href="%1">resend the activation email</a>."
 
 msgid "user.login.error.user-not-approved"
 msgstr "This user account has not yet been approved by the administrator; please <a href="%1">contact us</a> if you'd like to ask when this might be done, but try to remember that the website is run by volunteers giving up their time for free."
@@ -4520,7 +4550,7 @@ msgid "user.login.success.header"
 msgstr "Logged in"
 
 msgid "user.login.success.message"
-msgstr "Thank you for logging in %1.  You will now be redirected to the previous page; if this does not happen, please click <a href=\"%2\">here</a>."
+msgstr "Thank you for logging in %1.  You will now be redirected to the previous page; if this does not happen, please click <a href="%2">here</a>."
 
 msgid "user.login.success.status-message"
 msgstr "You have successfully logged in."

--- a/root/static/css/main-print.css
+++ b/root/static/css/main-print.css
@@ -436,8 +436,8 @@ table.vertical tr th {
   width: 50%;
   padding: 8px 10px;
   border-right: none;
-  /*width: 1%;*/
-  white-space: nowrap;
+  /*width: 1%;
+  white-space: nowrap;*/
 }
 
 table.vertical tr td {

--- a/root/static/css/main.css
+++ b/root/static/css/main.css
@@ -451,7 +451,7 @@ table.vertical tr th {
   padding: 8px 10px;
   border-right: none;
   /*width: 1%;*/
-  white-space: nowrap;
+  /*white-space: nowrap;*/
 }
 
 table.vertical tr td {

--- a/root/templates/html/fixtures-results/view-by-team.ttkt
+++ b/root/templates/html/fixtures-results/view-by-team.ttkt
@@ -64,33 +64,15 @@ END;
     CALL date.set_locale( c.locale );
 -%]
   <tr>
-    <td data-label="[% c.maketext("teams.fixtures.day") %]">
-      [% date.day_name | ucfirst | html_entity %]
-    </td>
-    <td data-label="[% c.maketext("teams.fixtures.day") %]">
-      [% date.day_of_week | ucfirst | html_entity %]
-    </td>
-    <td data-label="[% c.maketext("teams.fixtures.date") %]">
-      <a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) | html_entity %]</a>
-    </td>
-    <td data-label="[% c.maketext("teams.fixtures.date") %]">
-      [% date.ymd %]</a>
-    </td>
-    <td data-label="[% c.maketext("teams.fixtures.home") %] / [% c.maketext("teams.fixtures.away") %]">
-      [% location_text %]
-    </td>
-    <td data-label="[% c.maketext("teams.fixtures.opponent") %]">
-      <a href="[% opponent_uri %]">[% opponent.club_season.club.short_name | html_entity %] [% opponent.name | html_entity %]</a>
-    </td>
-    <td data-label="[% c.maketext("teams.fixtures.result") %]">
-      [% c.maketext(match_result.result.id) OR "&nbsp;" %]
-    </td>
-    <td data-label="[% c.maketext("teams.fixtures.score") %]">
-      <a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match_result.score OR c.maketext("matches.versus.not-yet-played") %]</a>
-    </td>
-    <td data-label="[% c.maketext("teams.fixtures.venue") %]">
-      <a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a>
-    </td>
+    <td data-label="[% c.maketext("teams.fixtures.day") %]">[% date.day_name | ucfirst | html_entity %]</td>
+    <td data-label="[% c.maketext("teams.fixtures.day") %]">[% date.day_of_week | ucfirst | html_entity %]</td>
+    <td data-label="[% c.maketext("teams.fixtures.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) | html_entity %]</a></td>
+    <td data-label="[% c.maketext("teams.fixtures.date") %]">[% date.ymd %]</td>
+    <td data-label="[% c.maketext("teams.fixtures.home") %] / [% c.maketext("teams.fixtures.away") %]">[% location_text %]</td>
+    <td data-label="[% c.maketext("teams.fixtures.opponent") %]"><a href="[% opponent_uri %]">[% opponent.club_season.club.short_name | html_entity %] [% opponent.name | html_entity %]</a></td>
+    <td data-label="[% c.maketext("teams.fixtures.result") %]">[% match_result.result OR "&nbsp;" %]</td>
+    <td data-label="[% c.maketext("teams.fixtures.score") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match_result.score OR c.maketext("matches.versus.not-yet-played") %]</a></td>
+    <td data-label="[% c.maketext("teams.fixtures.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;
 -%]

--- a/root/templates/html/matches/team/view.ttkt
+++ b/root/templates/html/matches/team/view.ttkt
@@ -43,9 +43,9 @@ END;
 [%
 IF match.cancelled;
 -%]
-  <div class="list-item">
-    [% c.maketext("matches.message.info.cancelled") %]
-  </div>
+    <div class="list-item">
+      [% c.maketext("matches.message.info.cancelled") %]
+    </div>
 [%
 ELSE;
 -%]
@@ -64,6 +64,7 @@ ELSE;
 [%
   FOREACH game IN match.team_match_games;
     #SET result = game.result;
+    SET score_html = ""; # Reset so we can check later if it's been set
     SET summary_score = game.summary_score;
 -%]
             <tr>
@@ -119,7 +120,7 @@ ELSE;
           SET away2_class = '';
           SET away2_class_end = '';
         END;
-      ELSE;
+      ELSE; # ELSE for IF game.doubles_game
         IF season.complete;
           SET home_uri = c.uri_for_action("/people/view_specific_season", [game.home_player.url_key, match.season.url_key]);
           SET away_uri = c.uri_for_action("/people/view_specific_season", [game.away_player.url_key, match.season.url_key]);
@@ -129,8 +130,8 @@ ELSE;
         END;
         
         # Filter the display names for HTML
-        home_name_html = FILTER html_entity; game.home_player.display_name; END;
-        away_name_html = FILTER html_entity; game.away_player.display_name; END;
+        home_name_html = game.home_player.display_name OR game.get_player_from_match_number({location => "home"}).display_name | html_entity;
+        away_name_html = game.away_player.display_name OR game.get_player_from_match_number({location => "away"}).display_name | html_entity;
         
         # Set player classes if the player isn't an active team member
         SWITCH game.singles_player_membership_type({"location" => "home"});
@@ -155,7 +156,7 @@ ELSE;
           CASE;
             SET away_class = '';
         END;
-      END;
+      END; # END for IF game.doubles_game
       
       IF game.awarded;
         # Game was awarded, so the text is different than if it wasn't.
@@ -178,15 +179,14 @@ ELSE;
           END;
         ELSE;
           # The game wasn't started - either the losing player(s) forefeited, or there are missing players
-          IF game.home_player_missing AND game.away_player_missing;
-            # Both players missing
-            SET result = c.maketext("matches.game.result.both-players-missing");
-          ELSIF game.home_player_missing;
+          IF game.home_player_missing;
             # Home player missing
-            SET result = c.maketext("matches.game.result.home-player-missing");
+            SET result = c.maketext("matches.game.result.home-player-missing", away_name_html, away_uri);
+            SET score_html = c.maketext("matches.game.score.home-player-missing");
           ELSIF game.away_player_missing;
             # Away player missing
-            SET result = c.maketext("matches.game.result.away-player-missing");
+            SET result = c.maketext("matches.game.result.away-player-missing", home_name_html, home_uri);
+            SET score_html = c.maketext("matches.game.score.away-player-missing");
           ELSE;
             # No players missing - forefeited
             IF game.winner.id == home_team.team.id;
@@ -204,8 +204,27 @@ ELSE;
             END;
           END;
         END;
-      ELSE;
-        # Game wasn't awarded, show the standard text - with player links
+      ELSIF game.void; # ELSIF for IF game.awarded
+        # The game was voided
+          IF game.home_player_missing AND game.away_player_missing;
+            # Both players missing
+            SET result = c.maketext("matches.game.result.void");
+            SET score_html = c.maketext("matches.game.score.both-players-missing");
+          ELSIF season.void_unplayed_games_if_both_teams_incomplete AND (game.home_player_missing OR game.away_player_missing);
+            # One player missing, but game is void
+            IF game.home_player_missing;
+              SET result = c.maketext("matches.game.result.void");
+              SET score_html = c.maketext("matches.game.score.home-player-missing-void");
+            ELSE;
+              SET result = c.maketext("matches.game.result.void");
+              SET score_html = c.maketext("matches.game.score.away-player-missing-void");
+            END;
+          ELSE;
+            # Game is void for another reason
+            SET result = c.maketext("matches.game.result.void");
+          END;
+      ELSE; # ELSE for IF game.awarded
+        # Game wasn't awarded or voided, show the standard text - with player links
         # Build the result string
         IF game.doubles_game;
           SET home_links = '<a href="' _ home_uri _ '">' _ home1_class _ home1_name_html _ home1_class_end _ ' ' _ c.maketext("matches.game.result.doubles-and") _ ' ' _ home2_class _ home2_name_html _ home2_class_end _ '</a>';
@@ -229,15 +248,15 @@ ELSE;
         END;
         
         SET result = home_links _ winner_text _ away_links;
-      END;
+      END; # END for IF game.awarded
 -%]
           <td>[% result %]
 [%-
-        IF summary_score.home OR summary_score.away;
+      IF summary_score.home OR summary_score.away;
 -%]
  ([% summary_score.home %]-[% summary_score.away %])
 [%-
-        END;
+      END;
 -%]
 </td>
 [%
@@ -256,7 +275,7 @@ ELSE;
           SET score_html = score_html _ '<span class="leg-score">' _ leg_score.home _ '-' _ leg_score.away _ '</span>';
           SET leg_number = leg_number + 1;
         END;
-      ELSE;
+      ELSIF score_html == "";
         # The game is marked as complete, but not started - score is not applicable, as it's been awarded
         SET score_html = c.maketext("msg.not-applicable");
       END;
@@ -264,7 +283,7 @@ ELSE;
           <td class="leg-scores">[% score_html %]</td>
           <td>[% game.home_team_match_score %]-[% game.away_team_match_score %]</td>
 [%
-    ELSE;
+    ELSE; # ELSE for IF game.complete
       # Game not yet played
 -%]
               <td>[% c.maketext("matches.game.score.not-yet-updated") %]</td>
@@ -275,34 +294,35 @@ ELSE;
 -%]
             </tr>
 [%
-  END;
+  END; # END for FOREACH game
 %]
           </tbody>
         </table>
 [%
-END;
-
-IF loan_players OR inactive;
+  IF loan_players OR inactive;
 -%]
         <div id="games-key">
 [%
-  IF loan_players;
+    IF loan_players;
 -%]
           <div class="loan-player-key">&nbsp;</div> [% c.maketext("team-membership-type.desc.loan") %]<br />
 [%
-  END;
-  IF inactive;
+    END;
+    IF inactive;
 -%]
           <div class="inactive-player-key">&nbsp;</div> [% c.maketext("team-membership-type.desc.inactive") %]<br />
 [%
-  END;
+    END;
 -%]
         </div>
 [%
-END;
+  END;
 -%]
       </div>
     </div>
+[%
+END; # END for IF match.cancelled
+-%]
   </div>
   <div id="teams">
 [%

--- a/root/templates/html/people/view.ttkt
+++ b/root/templates/html/people/view.ttkt
@@ -247,12 +247,16 @@ IF teams_count;
         SET score_html = c.maketext("msg.not-applicable");
       END;
       
-      IF game.winner.id == for_team.id;
-        SET result = c.maketext("matches.result.win");
-      ELSIF game.winner.id == against_team.id;
-        SET result = c.maketext("matches.result.loss");
+      IF game.complete;
+        IF game.winner.id == for_team.id;
+          SET result = c.maketext("matches.result.win");
+        ELSIF game.winner.id == against_team.id;
+          SET result = c.maketext("matches.result.loss");
+        ELSE;
+          SET result = c.maketext("matches.result.draw");
+        END;
       ELSE;
-        SET result = c.maketext("matches.result.draw");
+        SET result = c.maketext("matches.versus.not-yet-played");
       END;
 -%]
         <tr[% game_class %]>

--- a/root/templates/html/seasons/create-edit.ttkt
+++ b/root/templates/html/seasons/create-edit.ttkt
@@ -285,7 +285,7 @@ END;
 </fieldset>
 
 <fieldset>
-  <legend>[% c.maketext("seasons.form.legend.rules-when-games-not-completed") %]</legend>
+  <legend>[% c.maketext("seasons.award-forefeit-rules") %]</legend>
 [%
 IF void_unplayed_games_if_both_teams_incomplete;
   SET void_checked = ' checked="checked"';

--- a/root/templates/html/seasons/create-edit.ttkt
+++ b/root/templates/html/seasons/create-edit.ttkt
@@ -25,6 +25,9 @@ IF c.flash.show_flashed;
   SET loan_players_limit_per_player_per_team = c.flash.loan_players_limit_per_player_per_team;
   SET loan_players_limit_per_player_per_opposition = c.flash.loan_players_limit_per_player_per_opposition;
   SET loan_players_limit_per_team = c.flash.loan_players_limit_per_team;
+  SET void_unplayed_games_if_both_teams_incomplete = c.flash.void_unplayed_games_if_both_teams_incomplete;
+  SET forefeit_count_averages_if_game_not_started = c.flash.forefeit_count_averages_if_game_not_started;
+  SET missing_player_count_win_in_averages = c.flash.missing_player_count_win_in_averages;
 ELSE;
   SET start_date = season.start_date;
   SET end_date = season.end_date;
@@ -34,11 +37,11 @@ ELSE;
   SET timezone = season.timezone OR c.user.timezone OR c.config.I18N.locales.$locale.timezone OR c.config.DateTime.default_timezone;
   
   # We don't have a specific 'allow_loan_players' field in the DB, so the value of this is determined from at least one of the other fields being 1
-  SET allow_loan_players_across = season.allow_loan_players_below;
+  SET allow_loan_players_below = season.allow_loan_players_below;
   SET allow_loan_players_above = season.allow_loan_players_above;
   SET allow_loan_players_across = season.allow_loan_players_across;
   
-  IF allow_loan_players_across OR allow_loan_players_above OR allow_loan_players_across OR !season;
+  IF allow_loan_players_across OR allow_loan_players_above OR allow_loan_players_below OR !season;
     # Default to true for a new season, hence the !season being in the if statement
     SET allow_loan_players = 1;
   ELSE;
@@ -51,6 +54,9 @@ ELSE;
   SET loan_players_limit_per_player_per_team = season.loan_players_limit_per_player_per_team;
   SET loan_players_limit_per_player_per_opposition = season.loan_players_limit_per_player_per_opposition;
   SET loan_players_limit_per_team = season.loan_players_limit_per_team;
+  SET void_unplayed_games_if_both_teams_incomplete = season.void_unplayed_games_if_both_teams_incomplete;
+  SET forefeit_count_averages_if_game_not_started = season.forefeit_count_averages_if_game_not_started;
+  SET missing_player_count_win_in_averages = season.missing_player_count_win_in_averages;
 END;
 
 IF start_date;
@@ -65,7 +71,6 @@ END;
 IF restricted_edit == 1;
   SET restricted_disabled = ' disabled="disabled"';
 END;
-
 -%]
 
   <div class="label-field-container">
@@ -276,6 +281,36 @@ END;
         <div class="clear-fix"></div>
       </div>
     </div>
+  </div>
+</fieldset>
+
+<fieldset>
+  <legend>[% c.maketext("seasons.form.legend.rules-when-games-not-completed") %]</legend>
+[%
+IF void_unplayed_games_if_both_teams_incomplete;
+  SET void_checked = ' checked="checked"';
+ELSE;
+  SET void_checked = '';
+END;
+
+IF forefeit_count_averages_if_game_not_started;
+  SET forefeit_count_averages_checked = ' checked="checked"';
+ELSE;
+  SET forefeit_count_averages_checked = '';
+END;
+
+IF missing_player_count_win_in_averages;
+  SET missing_player_count_averages = ' checked="checked"';
+ELSE;
+  SET missing_player_count_averages = '';
+END;
+-%]
+  <div class="form-column">
+    <input type="checkbox" id="void_unplayed_games_if_both_teams_incomplete" name="void_unplayed_games_if_both_teams_incomplete" data-label="[% c.maketext("seasons.form.field.void-unplayed-games-if-both-teams-incomplete") %]" value="1"[% restricted_disabled _ void_checked %] />
+    <input type="checkbox" id="forefeit_count_averages_if_game_not_started" name="forefeit_count_averages_if_game_not_started" data-label="[% c.maketext("seasons.form.field.forefeit-count-averages-if-game-not-started") %]" value="1"[% restricted_disabled _ forefeit_count_averages_checked %] />
+  </div>
+  <div class="form-column">
+    <input type="checkbox" id="missing_player_count_win_in_averages" name="missing_player_count_win_in_averages" data-label="[% c.maketext("seasons.form.field.seasons.form.field.missing-player-count-win-in-averages") %]" value="1"[% restricted_disabled _ missing_player_count_averages %] />
   </div>
 </fieldset>
 

--- a/root/templates/html/seasons/view.ttkt
+++ b/root/templates/html/seasons/view.ttkt
@@ -1,6 +1,3 @@
-[% # Note That the '-' at the beginning or end of TT code  -%]
-[% # "chomps" the whitespace/newline at that end of the    -%]
-[% # output (use View Source in browser to see the effect) -%]
 <div class="row">
   <div class="column left">
     <h4>[% c.maketext("seasons.statistics") %]</h4>
@@ -46,9 +43,53 @@
         <td><a href="[% c.uri_for_action("/reports/view_specific_season", ["missing-players", season.url_key]) %]">[% matches_with_incomplete_teams %]</a></td>
       </tr>
     </table>
-  </div>
-  
-  <div class="column right">
+    
+    <h4>[% c.maketext("seasons.divisions") %]</h4>
+    <table id="datatable" class="stripe hover order-column row-border">
+      <thead>
+        <tr>
+          <th>[% c.maketext("seasons.division") %]</th>
+          <th>[% c.maketext("seasons.division.statistics") %]</th>
+          <th>&nbsp;</th>
+          <th>&nbsp;</th>
+          <th>&nbsp;</th>
+          <th>[% c.maketext("seasons.division.fixtures-grid") %]</th>
+          <th>[% c.maketext("seasons.league-match-template") %]</th>
+          <th>[% c.maketext("seasons.league-ranking-template") %]</th>
+        </tr>
+      </thead>
+      <tbody>
+[%
+FOREACH division IN divisions;
+  IF season.complete;
+    SET grid_uri = c.uri_for_action("/fixtures-grids/view_specific_season", [division.division_seasons.fixtures_grid.url_key, season.url_key]);
+    SET tables_uri = c.uri_for_action("/league-tables/view_specific_season", [division.url_key, season.url_key]);
+    SET singles_uri = c.uri_for_action("/league-averages/view_specific_season", ["singles", division.url_key, season.url_key]);
+    SET doubles_individuals_uri = c.uri_for_action("/league-averages/view_specific_season", ["doubles-individuals", division.url_key, season.url_key]);
+    SET doubles_pairs_uri = c.uri_for_action("/league-averages/view_specific_season", ["doubles-pairs", division.url_key, season.url_key]);
+  ELSE;
+    SET grid_uri = c.uri_for_action("/fixtures-grids/view_current_season", [division.division_seasons.fixtures_grid.url_key]);
+    SET tables_uri = c.uri_for_action("/league-tables/view_current_season", [division.url_key]);
+    SET singles_uri = c.uri_for_action("/league-averages/view_current_season", ["singles", division.url_key]);
+    SET doubles_individuals_uri = c.uri_for_action("/league-averages/view_current_season", ["doubles-individuals", division.url_key]);
+    SET doubles_pairs_uri = c.uri_for_action("/league-averages/view_current_season", ["doubles-pairs", division.url_key]);
+  END;
+-%]
+        <tr>
+          <td>[% division.name %]</td>
+          <td><a href="[% tables_uri %]">Tables</a></td>
+          <td><a href="[% singles_uri %]">Averages (Singles)</a></td>
+          <td><a href="[% doubles_individuals_uri %]">Averages (Individuals)</a></td>
+          <td><a href="[% doubles_pairs_uri %]">Averages (Doubles Pairs)</a></td>
+          <td><a href="[% grid_uri %]">[% division.division_seasons.fixtures_grid.name | html_entity %]</a></td>
+          <td><a href="[% c.uri_for_action("/templates/match/team/view", [division.division_seasons.league_match_template.url_key]) %]">[% division.division_seasons.league_match_template.name %]</a></td>
+          <td><a href="[% c.uri_for_action("/templates/league-table-ranking/view", [division.division_seasons.league_table_ranking_template.url_key]) %]">[% division.division_seasons.league_table_ranking_template.name | html_entity %]</a></td>
+        </tr>
+[%
+END;
+-%]
+      </tbody>
+    </table>
   [%
   IF season.complete;
     SET team_uri = c.uri_for_action("/fixtures-results/filter_view_specific_season", [season.url_key, "teams"]);
@@ -88,57 +129,156 @@
       </li>
     </ul>
   </div>
-</div>
-<!--<div class="clear-fix"></div>-->
-
-<div id="season-divisions">
-<h4>[% c.maketext("seasons.divisions") %]</h4>
-<table id="datatable" class="stripe hover order-column row-border">
-  <thead>
-    <tr>
-      <th>[% c.maketext("seasons.division") %]</th>
-      <th>[% c.maketext("seasons.division.statistics") %]</th>
-      <th>&nbsp;</th>
-      <th>&nbsp;</th>
-      <th>&nbsp;</th>
-      <th>[% c.maketext("seasons.division.fixtures-grid") %]</th>
-      <th>[% c.maketext("seasons.league-match-template") %]</th>
-      <th>[% c.maketext("seasons.league-ranking-template") %]</th>
-    </tr>
-  </thead>
-  <tbody>
+  
+  <div class="column right">
+    <h4>[% c.maketext("seasons.loan-player-rules") %]</h4>
+    <table class="vertical">
+      <tr>
+        <th scope="row">[% c.maketext("seasons.form.field.allow-loan-players-from-lower") %]</th>
 [%
-FOREACH division IN divisions;
-  IF season.complete;
-    SET grid_uri = c.uri_for_action("/fixtures-grids/view_specific_season", [division.division_seasons.fixtures_grid.url_key, season.url_key]);
-    SET tables_uri = c.uri_for_action("/league-tables/view_specific_season", [division.url_key, season.url_key]);
-    SET singles_uri = c.uri_for_action("/league-averages/view_specific_season", ["singles", division.url_key, season.url_key]);
-    SET doubles_individuals_uri = c.uri_for_action("/league-averages/view_specific_season", ["doubles-individuals", division.url_key, season.url_key]);
-    SET doubles_pairs_uri = c.uri_for_action("/league-averages/view_specific_season", ["doubles-pairs", division.url_key, season.url_key]);
+  IF season.allow_loan_players_below;
+    SET img_src = c.uri_for("/static/images/icons/0007-Tick-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-yes");
   ELSE;
-    SET grid_uri = c.uri_for_action("/fixtures-grids/view_current_season", [division.division_seasons.fixtures_grid.url_key]);
-    SET tables_uri = c.uri_for_action("/league-tables/view_current_season", [division.url_key]);
-    SET singles_uri = c.uri_for_action("/league-averages/view_current_season", ["singles", division.url_key]);
-    SET doubles_individuals_uri = c.uri_for_action("/league-averages/view_current_season", ["doubles-individuals", division.url_key]);
-    SET doubles_pairs_uri = c.uri_for_action("/league-averages/view_current_season", ["doubles-pairs", division.url_key]);
+    SET img_src = c.uri_for("/static/images/icons/0006-Cross-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-no");
   END;
 -%]
-    <tr>
-      <td>[% division.name %]</td>
-      <td><a href="[% tables_uri %]">Tables</a></td>
-      <td><a href="[% singles_uri %]">Averages (Singles)</a></td>
-      <td><a href="[% doubles_individuals_uri %]">Averages (Individuals)</a></td>
-      <td><a href="[% doubles_pairs_uri %]">Averages (Doubles Pairs)</a></td>
-      <td><a href="[% grid_uri %]">[% division.division_seasons.fixtures_grid.name | html_entity %]</a></td>
-      <td><a href="[% c.uri_for_action("/templates/match/team/view", [division.division_seasons.league_match_template.url_key]) %]">[% division.division_seasons.league_match_template.name %]</a></td>
-      <td><a href="[% c.uri_for_action("/templates/league-table-ranking/view", [division.division_seasons.league_table_ranking_template.url_key]) %]">[% division.division_seasons.league_table_ranking_template.name | html_entity %]</a></td>
-    </tr>
+        <td><img src="[% img_src %]" alt="[% img_title %]" title="[% img_title %]" /></td>
+      </tr>
+      <tr>
 [%
-END;
+  IF season.allow_loan_players_above;
+    SET img_src = c.uri_for("/static/images/icons/0007-Tick-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-yes");
+  ELSE;
+    SET img_src = c.uri_for("/static/images/icons/0006-Cross-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-no");
+  END;
 -%]
-  </tbody>
-</table>
-</div><br />
+        <th scope="row">[% c.maketext("seasons.form.field.allow-loan-players-from-higher") %]</th>
+        <td><img src="[% img_src %]" alt="[% img_title %]" title="[% img_title %]" /></td>
+      </tr>
+      <tr>
+[%
+  IF season.allow_loan_players_across;
+    SET img_src = c.uri_for("/static/images/icons/0007-Tick-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-yes");
+  ELSE;
+    SET img_src = c.uri_for("/static/images/icons/0006-Cross-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-no");
+  END;
+-%]
+        <th scope="row">[% c.maketext("seasons.form.field.allow-loan-players-from-same-level") %]</th>
+        <td><img src="[% img_src %]" alt="[% img_title %]" title="[% img_title %]" /></td>
+      </tr>
+      <tr>
+[%
+  IF season.allow_loan_players_same_club_only;
+    SET img_src = c.uri_for("/static/images/icons/0007-Tick-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-yes");
+  ELSE;
+    SET img_src = c.uri_for("/static/images/icons/0006-Cross-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-no");
+  END;
+-%]
+        <th scope="row">[% c.maketext("seasons.form.field.loan-players-from-same-club-only") %]</th>
+        <td><img src="[% img_src %]" alt="[% img_title %]" title="[% img_title %]" /></td>
+      </tr>
+      <tr>
+[%
+  IF season.allow_loan_players_multiple_teams_per_division;
+    SET img_src = c.uri_for("/static/images/icons/0007-Tick-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-yes");
+  ELSE;
+    SET img_src = c.uri_for("/static/images/icons/0006-Cross-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-no");
+  END;
+-%]
+        <th scope="row">[% c.maketext("seasons.form.field.allow-loan-players-multiple-teams-per-division") %]</th>
+        <td><img src="[% img_src %]" alt="[% img_title %]" title="[% img_title %]" /></td>
+      </tr>
+      <tr>
+[%
+  IF season.loan_players_limit_per_player > 0;
+    SET loan_players_limit_per_player = season.loan_players_limit_per_player;
+  ELSE;
+    SET loan_players_limit_per_player = c.maketext("seasons.loan-players.no-limit");
+  END;
+-%]
+        <th scope="row">[% c.maketext("seasons.form.field.loan-players-limit-per-player") %]</th>
+        <td>[% loan_players_limit_per_player %]</td>
+      </tr>
+      <tr>
+[%
+  IF season.loan_players_limit_per_player_per_team > 0;
+    SET loan_players_limit_per_player_per_team = season.loan_players_limit_per_player_per_team;
+  ELSE;
+    SET loan_players_limit_per_player_per_team = c.maketext("seasons.loan-players.no-limit");
+  END;
+-%]
+        <th scope="row">[% c.maketext("seasons.form.field.loan-players-limit-per-player-per-team") %]</th>
+        <td>[% loan_players_limit_per_player_per_team %]</td>
+      </tr>
+      <tr>
+[%
+  IF season.loan_players_limit_per_player_per_opposition > 0;
+    SET loan_players_limit_per_player_per_opposition = season.loan_players_limit_per_player_per_opposition;
+  ELSE;
+    SET loan_players_limit_per_player_per_opposition = c.maketext("seasons.loan-players.no-limit");
+  END;
+-%]
+        <th scope="row">[% c.maketext("seasons.form.field.loan-players-limit-per-opposition") %]</th>
+        <td>[% loan_players_limit_per_player_per_opposition %]</td>
+      </tr>
+    </table>
+    
+    <h4>[% c.maketext("seasons.award-forefeit-rules") %]</h4>
+    <table class="vertical">
+      <tr>
+        <th scope="row">[% c.maketext("seasons.form.field.void-unplayed-games-if-both-teams-incomplete") %]</th>
+[%
+  IF season.void_unplayed_games_if_both_teams_incomplete;
+    SET img_src = c.uri_for("/static/images/icons/0007-Tick-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-yes");
+  ELSE;
+    SET img_src = c.uri_for("/static/images/icons/0006-Cross-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-no");
+  END;
+-%]
+        <td><img src="[% img_src %]" alt="[% img_title %]" title="[% img_title %]" /></td>
+      </tr>
+      <tr>
+        <th scope="row">[% c.maketext("seasons.form.field.seasons.form.field.missing-player-count-win-in-averages") %]</th>
+[%
+  IF season.missing_player_count_win_in_averages;
+    SET img_src = c.uri_for("/static/images/icons/0007-Tick-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-yes");
+  ELSE;
+    SET img_src = c.uri_for("/static/images/icons/0006-Cross-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-no");
+  END;
+-%]
+        <td><img src="[% img_src %]" alt="[% img_title %]" title="[% img_title %]" /></td>
+      </tr>
+      <tr>
+        <th scope="row">[% c.maketext("seasons.form.field.forefeit-count-averages-if-game-not-started") %]</th>
+[%
+  IF season.forefeit_count_averages_if_game_not_started;
+    SET img_src = c.uri_for("/static/images/icons/0007-Tick-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-yes");
+  ELSE;
+    SET img_src = c.uri_for("/static/images/icons/0006-Cross-icon-32.png");
+    SET img_title = c.maketext("seasons.allowed-no");
+  END;
+-%]
+        <td><img src="[% img_src %]" alt="[% img_title %]" title="[% img_title %]" /></td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+
 
 <div id="season-events">
 <h4>[% c.maketext("seasons.events") %]</h4>

--- a/root/templates/html/wrappers/responsive.ttkt
+++ b/root/templates/html/wrappers/responsive.ttkt
@@ -634,7 +634,6 @@ ELSE;
   <li data-sm-reverse="true">
     <a href="[% c.uri_for("/login") %]" title="[% c.maketext("user.login") %] / [% c.maketext("user.register") %]">[% c.maketext("user.login") %] / [% c.maketext("user.register") %]</a>
     <ul class="mega-menu">
-      <div class="no-cookies">
       <form method="post" action="[% c.uri_for_action("/users/do_login") %]">
       <input type="text" class="menu-input menu-margin" name="username" id="menu-username" value="[% c.request.cookie("toptable_username").value | html_entity %]" placeholder="[% c.maketext("user.field.username") %]">
       <input type="password" class="menu-input menu-margin" name="password" id="menu-password" value="" placeholder="[% c.maketext("user.field.password") %]">
@@ -642,7 +641,6 @@ ELSE;
       <input type="submit" class="menu-margin" value="[% c.maketext("user.login") %]" /><br />
       <a class="menu-margin" style="display: inline; background: #fff; padding: 0px; color: #000; text-shadow: 0px 0px 0px #000" href="[% c.uri_for("/register") %]">[% c.maketext("user.register") %]</a>
       </form>
-      </div>
     </ul>
   </li>
 [%


### PR DESCRIPTION
- **[New]** Implementation of new season rules: void_unplayed_games_if_both_teams_incomplete, forefeit_count_averages_if_game_not_started, missing_player_count_win_in_averages.
- **[New]** Better game descriptions for voided / awarded games.
- **[New]** home_players_absent and away_players_absent result methods added to TeaMatch class.
- **[New]** Removal of unneeded debug logging.
- **[New]** Removal of 'no-cookies' div in login form on the menu.

Closes #115 