### PR TITLE
Fix to venue select in meetings

### DIFF
--- a/root/templates/html/meetings/create-edit.ttkt
+++ b/root/templates/html/meetings/create-edit.ttkt
@@ -76,7 +76,7 @@ WHILE (venue_loop = venues.next);
     SET selected = '';
   END;
 -%]
-        <option value="[% venue.id %]"[% selected %]>[% venue.name | html_entity %]</option>
+        <option value="[% venue_loop.id %]"[% selected %]>[% venue_loop.name | html_entity %]</option>
 [%
 END;
 -%]


### PR DESCRIPTION
- **[Fix]** Incorrect value used for venues in select box loop in meetings causing an empty select box, fixed.