### PR TITLE
Fixtures grid changes/common resultset methods

### DIFF
--- a/lib/TopTable/Controller/Info/Officials/Positions.pm
+++ b/lib/TopTable/Controller/Info/Officials/Positions.pm
@@ -237,7 +237,8 @@ sub edit :Chained("base") :PathPart("edit") :Args(0) {
       $holders = $c->flash->{holders};
     } else {
       $holders = $position->get_holders({season => $current_season});
-      $holders = [$holders->all] if defined($holders);    }
+      $holders = [$holders->all] if defined($holders);
+    }
     
     $tokeninput_options->{prePopulate} = [map({
       id => $_->id,

--- a/lib/TopTable/Controller/Users.pm
+++ b/lib/TopTable/Controller/Users.pm
@@ -5,6 +5,7 @@ use DateTime;
 use DateTime::TimeZone;
 use DateTime::Duration;
 use HTML::Entities;
+#use DDP;
 
 BEGIN { extends 'Catalyst::Controller'; }
 
@@ -1859,6 +1860,7 @@ sub check_authorisation :Private {
       
       # Extract the name column for each returned value
       @role_names = map($_->name, @roles);
+      #$c->log->debug(sprintf("check auth on $action: %s", np(@role_names)));
       
       if ( $c->check_any_user_role(@role_names) ) {
         # We are in one of the roles that is authorised, set allowed flag

--- a/lib/TopTable/Schema/Result/FixturesGridMatch.pm
+++ b/lib/TopTable/Schema/Result/FixturesGridMatch.pm
@@ -74,6 +74,26 @@ __PACKAGE__->table("fixtures_grid_matches");
   extra: {unsigned => 1}
   is_nullable: 1
 
+=head2 home_team_type
+
+  data_type: 'varchar'
+  default_value: 'static'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 20
+
+static = home_team number references a team in the grid; dynamic-winner = home_team references a match from the previous round, the winner of that match is used; dynamic-loser = home_team references a match from the previous round, the loser of that match is used
+
+=head2 away_team_type
+
+  data_type: 'varchar'
+  default_value: 'static'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 20
+
+static = away_team number references a team in the grid; dynamic-winner = away_team references a match from the previous round, the winner of that match is used; dynamic-loser = away_team references a match from the previous round, the loser of that match is used
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -97,6 +117,22 @@ __PACKAGE__->add_columns(
   { data_type => "tinyint", extra => { unsigned => 1 }, is_nullable => 1 },
   "away_team",
   { data_type => "tinyint", extra => { unsigned => 1 }, is_nullable => 1 },
+  "home_team_type",
+  {
+    data_type => "varchar",
+    default_value => "static",
+    is_foreign_key => 1,
+    is_nullable => 0,
+    size => 20,
+  },
+  "away_team_type",
+  {
+    data_type => "varchar",
+    default_value => "static",
+    is_foreign_key => 1,
+    is_nullable => 0,
+    size => 20,
+  },
 );
 
 =head1 PRIMARY KEY
@@ -117,6 +153,21 @@ __PACKAGE__->set_primary_key("grid", "week", "match_number");
 
 =head1 RELATIONS
 
+=head2 away_team_type
+
+Type: belongs_to
+
+Related object: L<TopTable::Schema::Result::LookupGridTeamType>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "away_team_type",
+  "TopTable::Schema::Result::LookupGridTeamType",
+  { id => "away_team_type" },
+  { is_deferrable => 1, on_delete => "RESTRICT", on_update => "RESTRICT" },
+);
+
 =head2 fixtures_grid_week
 
 Type: belongs_to
@@ -132,9 +183,24 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 1, on_delete => "CASCADE", on_update => "RESTRICT" },
 );
 
+=head2 home_team_type
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-09-04 12:04:55
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0yzYThN8SEwoh7wL0/ZB5Q
+Type: belongs_to
+
+Related object: L<TopTable::Schema::Result::LookupGridTeamType>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "home_team_type",
+  "TopTable::Schema::Result::LookupGridTeamType",
+  { id => "home_team_type" },
+  { is_deferrable => 1, on_delete => "RESTRICT", on_update => "RESTRICT" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-07-01 00:21:01
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qZtP+DxVCYhVAqMGiqeJLQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/TopTable/Schema/Result/LookupGridTeamType.pm
+++ b/lib/TopTable/Schema/Result/LookupGridTeamType.pm
@@ -1,0 +1,133 @@
+use utf8;
+package TopTable::Schema::Result::LookupGridTeamType;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+TopTable::Schema::Result::LookupGridTeamType
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=item * L<DBIx::Class::PassphraseColumn>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
+
+=head1 TABLE: C<lookup_grid_team_type>
+
+=cut
+
+__PACKAGE__->table("lookup_grid_team_type");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'varchar'
+  is_nullable: 0
+  size: 20
+
+=head2 type
+
+  data_type: 'varchar'
+  default_value: (empty string)
+  is_nullable: 0
+  size: 10
+
+=head2 player
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 10
+
+=head2 display_order
+
+  data_type: 'tinyint'
+  is_nullable: 0
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  { data_type => "varchar", is_nullable => 0, size => 20 },
+  "type",
+  { data_type => "varchar", default_value => "", is_nullable => 0, size => 10 },
+  "player",
+  { data_type => "varchar", is_nullable => 1, size => 10 },
+  "display_order",
+  { data_type => "tinyint", is_nullable => 0 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+=head1 RELATIONS
+
+=head2 fixtures_grid_matches_away_team_types
+
+Type: has_many
+
+Related object: L<TopTable::Schema::Result::FixturesGridMatch>
+
+=cut
+
+__PACKAGE__->has_many(
+  "fixtures_grid_matches_away_team_types",
+  "TopTable::Schema::Result::FixturesGridMatch",
+  { "foreign.away_team_type" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 fixtures_grid_matches_home_team_types
+
+Type: has_many
+
+Related object: L<TopTable::Schema::Result::FixturesGridMatch>
+
+=cut
+
+__PACKAGE__->has_many(
+  "fixtures_grid_matches_home_team_types",
+  "TopTable::Schema::Result::FixturesGridMatch",
+  { "foreign.home_team_type" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-08-15 20:43:21
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:AWPlT8LWipcKdYH858zfMg
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/TopTable/Schema/Result/User.pm
+++ b/lib/TopTable/Schema/Result/User.pm
@@ -233,7 +233,7 @@ __PACKAGE__->table("users");
   data_type: 'tinyint'
   default_value: 1
   extra: {unsigned => 1}
-  is_nullable: 0
+  is_nullable: 1
 
 =head2 approved_by
 
@@ -412,7 +412,7 @@ __PACKAGE__->add_columns(
     data_type => "tinyint",
     default_value => 1,
     extra => { unsigned => 1 },
-    is_nullable => 0,
+    is_nullable => 1,
   },
   "approved_by",
   {
@@ -738,8 +738,8 @@ Composing rels: L</user_roles> -> role
 __PACKAGE__->many_to_many("roles", "user_roles", "role");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-05-29 08:34:29
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:fT2pA0xTl0728wde3Jf+3g
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-08-15 20:43:22
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZJpN8SPoLV5LkuWB6xfHOA
 
 use DateTime;
 use DateTime;

--- a/lib/TopTable/Schema/ResultSet.pm
+++ b/lib/TopTable/Schema/ResultSet.pm
@@ -1,0 +1,121 @@
+package TopTable::Schema::ResultSet;
+use strict;
+use warnings;
+use base qw( DBIx::Class::ResultSet );
+
+=head2 find_url_key
+
+Same as find(), but uses the key column instead of the id.  So we can use human-readable URLs.
+
+=cut
+
+sub find_url_key {
+  my ( $class, $url_key ) = @_;
+  return $class->find({url_key => $url_key});
+}
+
+=head2 find_id_or_url_key
+
+Same as find(), but searches for both the id and key columns.  So we can use human-readable URLs.
+
+=cut
+
+sub find_id_or_url_key {
+  my ( $class, $id_or_url_key ) = @_;
+  my $where;
+  
+  if ( $id_or_url_key =~ m/^\d+$/ ) {
+    # Numeric - look in ID or URL key
+    $where = [{
+      "me.id" => $id_or_url_key
+    }, {
+      "me.url_key" => $id_or_url_key
+    }];
+  } else {
+    # Not numeric - must be the URL key
+    $where = {"me.url_key" => $id_or_url_key};
+  }
+  
+  return $class->search($where, {rows => 1})->single;
+}
+
+=head2 make_url_key
+
+Generate a unique key from the given name.  Must be used on a resultset where the objects have an id and url_key field.
+
+=cut
+
+sub make_url_key {
+  my ( $class, $name, $exclusion_obj ) = @_;
+  my $url_key;
+  ( my $original_url_key = substr($name, 0, 45) ) =~ s/[ \W]/-/g; # Truncate after 45 characters, swap out spaces and non-word characters for dashes
+  $original_url_key =~ s/-+/-/g; # If we find more than one dash in a row, replace it with just one.
+  $original_url_key =~ s/^-|-$//g; # Replace dashes at the start and end with nothing
+  $original_url_key = lc($original_url_key); # Make lower-case
+  
+  my $count;
+  # Infinite loop; we'll break when we can't find the key
+  while ( 1 ) {
+    if ( defined($count) ) {
+      $count = 2 if $count == 1; # We won't have a 1 - if we reach the point where count is a number, we want to start at 2
+      
+      # If we have a count, we will add it on to the end of the original key
+      $url_key = sprintf("%s-%d", $original_url_key, $count);
+    } else {
+      $url_key = $original_url_key;
+    }
+    
+    # Check if that key already exists
+    my $conflict;
+    if ( defined($exclusion_obj) ) {
+      # Find anything with this value, excluding the exclusion object passed in
+      $conflict = $class->find({}, {
+        where => {
+          url_key => $url_key,
+          id => {"!=" => $exclusion_obj->id},
+        }
+      });
+    } else {
+      # Find anything with this value
+      $conflict = $class->find({url_key => $url_key});
+    }
+    
+    # If not, return it
+    return $url_key unless defined($conflict);
+    
+    # Otherwise, we need to increment the count for the next loop round
+    $count++;
+  }
+}
+
+
+=head2 search_single_field
+
+Check the field given in the parameter 'field' for the value given in 'value'.  Optionally takes an 'exclusion_obj', which is excluded from the search (this is useful if we want to check if a supposedly unique value is already entered, but want to exclude the object we're supposed to be editing).
+
+Returns the results of the find (which is obviously undef if nothing comes back).
+
+=cut
+
+sub search_single_field {
+  my ( $class, $params ) = @_;
+  my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
+  my $field = $params->{field};
+  my $value = $params->{value};
+  my $exclusion_obj = $params->{exclusion_obj};
+  
+  if ( defined($exclusion_obj) ) {
+    # Find anything with this value, excluding the exclusion object passed in
+    return $class->find({}, {
+      where => {
+        $field => $value,
+        id => {"!=" => $exclusion_obj->id},
+      }
+    });
+  } else {
+    # Find anything with this value
+    return $class->find({$field => $value});
+  }
+}
+
+1;

--- a/lib/TopTable/Schema/ResultSet/Club.pm
+++ b/lib/TopTable/Schema/ResultSet/Club.pm
@@ -2,7 +2,7 @@ package TopTable::Schema::ResultSet::Club;
 
 use strict;
 use warnings;
-use base 'DBIx::Class::ResultSet';
+use base qw( TopTable::Schema::ResultSet );
 use HTML::Entities;
 use Regexp::Common qw( URI );
 
@@ -351,7 +351,7 @@ sub create_or_edit {
   # Check the names were entered and don't exist already.
   if ( defined($full_name) ) {
     # Full name entered, check it.
-    push(@{$response->{errors}}, $lang->maketext("clubs.form.error.full-name-exists", $full_name)) if defined($self->check_field({field => "full_name", value => $full_name, exclusion_obj => $club}));
+    push(@{$response->{errors}}, $lang->maketext("clubs.form.error.full-name-exists", $full_name)) if defined($self->check_duplicates({field => "full_name", value => $full_name, exclusion_obj => $club}));
   } else {
     # Full name omitted.
     push(@{$response->{errors}}, $lang->maketext("clubs.form.error.full-name-blank"));
@@ -359,7 +359,7 @@ sub create_or_edit {
   
   if ( defined($short_name) ) {
     # Full name entered, check it.
-    push(@{$response->{errors}}, $lang->maketext("clubs.form.error.short-name-exists", $short_name)) if defined($self->check_field({field => "short_name", value => $short_name, exclusion_obj => $club}));
+    push(@{$response->{errors}}, $lang->maketext("clubs.form.error.short-name-exists", $short_name)) if defined($self->check_duplicates({field => "short_name", value => $short_name, exclusion_obj => $club}));
   } else {
     # Full name omitted.
     push(@{$response->{errors}}, $lang->maketext("clubs.form.error.short-name-blank"));
@@ -367,7 +367,7 @@ sub create_or_edit {
   
   if ( defined($abbreviated_name) ) {
     # Full name entered, check it.
-    push(@{$response->{errors}}, $lang->maketext("clubs.form.error.abbreviated-name-exists", $abbreviated_name)) if defined($self->check_field({field => "abbreviated_name", value => $abbreviated_name, exclusion_obj => $club}));
+    push(@{$response->{errors}}, $lang->maketext("clubs.form.error.abbreviated-name-exists", $abbreviated_name)) if defined($self->check_duplicates({field => "abbreviated_name", value => $abbreviated_name, exclusion_obj => $club}));
   } else {
     # Full name omitted.
     push(@{$response->{errors}}, $lang->maketext("clubs.form.error.abbreviated-name-blank"));
@@ -474,26 +474,6 @@ sub create_or_edit {
   }
   
   return $response;
-}
-
-sub check_field {
-  my ( $self, $params ) = @_;
-  my $field = delete $params->{field};
-  my $value = delete $params->{value};
-  my $exclusion_obj = delete $params->{exclusion_obj};
-  
-  if ( defined( $exclusion_obj ) ) {
-    # Find anything with this value, excluding the exclusion object passed in
-    return $self->find({}, {
-      where => {
-        $field => $value,
-        id => {"!=" => $exclusion_obj->id},
-      }
-    });
-  } else {
-    # Find anything with this value
-    return $self->find({$field => $value});
-  }
 }
 
 1;

--- a/lib/TopTable/Schema/ResultSet/FixturesGrid.pm
+++ b/lib/TopTable/Schema/ResultSet/FixturesGrid.pm
@@ -2,7 +2,8 @@ package TopTable::Schema::ResultSet::FixturesGrid;
 
 use strict;
 use warnings;
-use base 'DBIx::Class::ResultSet';
+use base qw( TopTable::Schema::ResultSet );
+use HTML::Entities;
 
 =head2 all_grids
 
@@ -11,9 +12,9 @@ Return all fixtures grids sorted by name.
 =cut
 
 sub all_grids {
-  my ( $self ) = @_;
+  my ( $class ) = @_;
   
-  return $self->search(undef, {
+  return $class->search(undef, {
     order_by => {-asc => qw( name )},
   });
 }
@@ -25,27 +26,25 @@ Return search results based on a supplied full or partial name.
 =cut
 
 sub search_by_name {
-  my ( $self, $params ) = @_;
-  my $q = delete $params->{q};
-  my $split_words = delete $params->{split_words} || 0;
-  my $season = delete $params->{season};
+  my ( $class, $params ) = @_;
+  my $q = $params->{q};
+  my $split_words = $params->{split_words} || 0;
+  my $season = $params->{season};
   my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
-  my $page = delete $params->{page} || undef;
-  my $results_per_page = delete $params->{results} || undef;
+  my $page = $params->{page} || undef;
+  my $results_per_page = $params->{results} || undef;
   
   # Construct the LIKE '%word1%' AND  LIKE '%word2%' etc.  I couldn't work out how to map this, so a loop it is.
   my ( $where );
   if ( $split_words ) {
-    my @words = split( /\s+/, $q );
+    my @words = split(/\s+/, $q);
     my @constructed_like = ("-and");
     foreach my $word ( @words ) {
-      my $constructed_like = { -like => "%$word%" };
-      push ( @constructed_like, $constructed_like );
+      my $constructed_like = {-like => "%$word%"};
+      push (@constructed_like, $constructed_like);
     }
     
-    $where = [{
-      name => \@constructed_like,
-    }];
+    $where = [{name => \@constructed_like}];
   } else {
     # Don't split words up before performing a like
     $where = {
@@ -55,14 +54,14 @@ sub search_by_name {
   
   my $attrib = {
     order_by => {-asc => [ qw( name ) ]},
-    group_by => [ qw( name ) ],
+    group_by => [qw( name )],
   };
   
-  my $use_paging = ( defined( $page ) ) ? 1 : 0;
+  my $use_paging = defined($page) ? 1 : 0;
   
   if ( $use_paging ) {
     # Set a default for results per page if it's not provided or invalid
-    $results_per_page = 25 if !defined( $results_per_page ) or $results_per_page !~ m/^\d+$/;
+    $results_per_page = 25 if !defined($results_per_page) or $results_per_page !~ m/^\d+$/;
     
     # Default the page number to 1
     $page = 1 if $page !~ m/^\d+$/;
@@ -72,11 +71,11 @@ sub search_by_name {
     $attrib->{rows} = $results_per_page;
   }
   
-  if ( defined( $season ) ) {
+  if ( defined($season) ) {
     $where->[0]{season} = $season->id;
   }
   
-  return $self->search( $where, $attrib );
+  return $class->search($where, $attrib);
 }
 
 =head2 page_records
@@ -86,7 +85,7 @@ Returns a paginated resultset of fixtures grids.
 =cut
 
 sub page_records {
-  my ( $self, $parameters ) = @_;
+  my ( $class, $parameters ) = @_;
   my $page_number = $parameters->{page_number} || 1;
   my $results_per_page = $parameters->{results_per_page} || 25;
   
@@ -96,7 +95,7 @@ sub page_records {
   # Default the page number to 1
   $page_number = 1 if !defined($page_number) or $page_number !~ m/^\d+$/;
   
-  return $self->search(undef, {
+  return $class->search(undef, {
     page => $page_number,
     rows => $results_per_page,
     order_by => {-asc => qw( name )},
@@ -110,9 +109,9 @@ A predefined search to get the matches for a grid in week number, then match num
 =cut
 
 sub incomplete_matches {
-  my ( $self, $grid ) = @_;
+  my ( $class, $grid ) = @_;
   
-  return $self->search({
+  return $class->search({
     -or => [{
       "fixtures_grid_matches.home_team" => undef,
       "fixtures_grid_matches.away_team" => undef,
@@ -121,13 +120,9 @@ sub incomplete_matches {
       id => $grid->id
     },
   }, {
-    join => {
-      fixtures_grid_weeks => "fixtures_grid_matches",
-    },
+    join => {fixtures_grid_weeks => "fixtures_grid_matches"},
     order_by => {
-      -asc => [
-        qw( fixtures_grid_weeks.week fixtures_grid_matches.match_number )
-      ]
+      -asc => [qw( fixtures_grid_weeks.week fixtures_grid_matches.match_number )]
     },
   });
 }
@@ -139,16 +134,14 @@ Returns the count of teams that have incomplete grid positions for a given grid 
 =cut
 
 sub incomplete_grid_positions {
-  my ( $self, $grid, $season ) = @_;
+  my ( $class, $grid, $season ) = @_;
   
-  return $self->search({
-    "me.id"                       => $grid->id,
-    "team_seasons.grid_position"  => undef,
+  return $class->search({
+    "me.id" => $grid->id,
+    "team_seasons.grid_position" => undef,
   }, {
     join => {
-      division_seasons => {
-        season => "team_seasons",
-      },
+      division_seasons => {season => "team_seasons"},
     },
   })->count;
 }
@@ -160,91 +153,13 @@ Wraps find() with a prefetch on season weeks.
 =cut
 
 sub find_with_weeks {
-  my ( $self, $grid_id ) = @_;
+  my ( $class, $grid_id ) = @_;
   
-  return $self->find({
+  return $class->find({
     id  => $grid_id,
   }, {
     prefetch => "fixtures_grid_weeks",
   });
-}
-
-=head2 find_key
-
-Same as find(), but uses the key column instead of the id.  So we can use human-readable URLs.
-
-=cut
-
-sub find_url_key {
-  my ( $self, $url_key ) = @_;
-  
-  return $self->find({
-    url_key => $url_key,
-  });
-}
-
-=head2 find_id_or_url_key
-
-Same as find(), but searches for both the id and key columns.  So we can use human-readable URLs.
-
-=cut
-
-sub find_id_or_url_key {
-  my ( $self, $id_or_url_key ) = @_;
-  my $where;
-  
-  if ( $id_or_url_key =~ m/^\d+$/ ) {
-    # Numeric - look in ID or URL key
-    $where = [{
-      id => $id_or_url_key
-    }, {
-      "me.url_key" => $id_or_url_key
-    }];
-  } else {
-    # Not numeric - must be the URL key
-    $where = {"me.url_key" => $id_or_url_key};
-  }
-  
-  return $self->search($where, {
-    rows => 1,
-  })->single;
-}
-
-=head2 generate_url_key
-
-Generate a unique key from the given template name.
-
-=cut
-
-sub generate_url_key {
-  my ( $self, $short_name, $exclude_id ) = @_;
-  my $url_key;
-  ( my $original_url_key = substr($short_name, 0, 45) ) =~ s/[ \W]/-/g; # Truncate after 45 characters, swap out spaces and non-word characters for dashes
-  $original_url_key =~ s/-+/-/g; # If we find more than one dash in a row, replace it with just one.
-  $original_url_key =~ s/^-|-$//g; # Replace dashes at the start and end with nothing
-  $original_url_key = lc( $original_url_key ); # Make lower-case
-  
-  my $count;
-  # Infinite loop; we'll break when we can't find the key
-  while ( 1 ) {
-    if ( defined($count) ) {
-      $count = 2 if $count == 1; # We won't have a 1 - if we reach the point where count is a number, we want to start at 2
-      
-      # If we have a count, we will add it on to the end of the original key
-      $url_key = $original_url_key . "-" . $count;
-    } else {
-      $url_key = $original_url_key;
-    }
-    
-    # Check if that key already exists
-    my $key_check = $self->find_url_key( $url_key );
-    
-    # If not, return it
-    return $url_key if !defined( $key_check ) or ( defined($exclude_id) and $key_check->id == $exclude_id );
-    
-    # Otherwise, we need to increment the count for the next loop round
-    $count++;
-  }
 }
 
 =head2 create_or_edit
@@ -254,19 +169,19 @@ Provides the wrapper (including error checking) for adding / editing a fixtures 
 =cut
 
 sub create_or_edit {
-  my ( $self, $action, $params ) = @_;
+  my ( $class, $action, $params ) = @_;
   # Setup schema / logging
   my $logger = delete $params->{logger} || sub { my $level = shift; printf "LOG - [%s]: %s\n", $level, @_; }; # Default to a sub that prints the log, as we don't want errors if we haven't passed in a logger.
   my $locale = delete $params->{locale} || "en_GB"; # Usually handled by the app, other clients (i.e., for cmdline testing) can pass it in.
-  my $schema = $self->result_source->schema;
+  my $schema = $class->result_source->schema;
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   
   # Grab the fields
-  my $grid = delete $params->{grid};
-  my $name = delete $params->{name};
-  my $maximum_teams = delete $params->{maximum_teams};
-  my $fixtures_repeated = delete $params->{fixtures_repeated};
+  my $grid = $params->{grid};
+  my $name = $params->{name};
+  my $maximum_teams = $params->{maximum_teams};
+  my $fixtures_repeated = $params->{fixtures_repeated};
   my $response = {
     errors => [],
     warnings => [],
@@ -286,83 +201,78 @@ sub create_or_edit {
     
     return $response;
   } elsif ($action eq "edit") {
-    unless ( defined( $grid ) and ref( $grid ) eq "TopTable::Model::DB::FixturesGrid" ) {
+    unless ( defined($grid) and ref($grid) eq "TopTable::Model::DB::FixturesGrid" ) {
       # Editing a fixtures grid that doesn't exist.
       push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.grid-invalid"));
       return $response;
     }
   }
   
+  # See if we're setting up fixtures rounds (we won't if we're editing a restricted grid - i.e., it already has matches attached)
+  my $setup_rounds = 1;
+  $setup_rounds = 0 if $action eq "edit" and $grid->restricted_edit;
+  
   # Error checking
   # Check the names were entered and don't exist already.
-  if ( $name ) {
-    # Full name entered, check it.
-    my $grid_name_check;
-    if ( $action eq "edit" ) {
-      $grid_name_check = $self->find({}, {
-        where => {
-          name  => $name ,
-          id    => {"!=" => $grid->id}
-        }
-      });
-    } else {
-      $grid_name_check = $self->find({name => $name});
-    }
-    
-    push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.grid-exists")) if defined( $grid_name_check );
+  if ( defined($name) ) {
+    push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.grid-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $grid}));
   } else {
-    # Full name omitted.
-    push(@{ $response->{errors} }, $lang->maketext("fixtures-grids.form.error.name-blank"));
+    # Name omitted.
+    push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.name-blank"));
   }
   
-  # Check the maximum teams is a valid numeric value (2-98, even only).
-  push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.maximum-teams-invalid")) if !$maximum_teams or $maximum_teams !~ m/^\d{1,2}$/ or $maximum_teams < 2 or $maximum_teams > 98 or $maximum_teams % 2 == 1;
-  
-  # Check the number of weeks is valid; this needs to be a valid numeric figure and
-  # less than 52, as a season will definitely not last a year.
-  push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.repeat-fixtures-invalid")) if !$fixtures_repeated or $fixtures_repeated !~ m/^\d$/ or $fixtures_repeated < 1;
+  if ( $setup_rounds ) {
+    # Check the maximum teams is a valid numeric value (2-98).
+    push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.maximum-teams-invalid")) if !$maximum_teams or $maximum_teams !~ m/^\d{1,2}$/ or $maximum_teams < 2 or $maximum_teams > 98 or $maximum_teams % 2 == 1;
+    
+    # Check the number of weeks is valid; this needs to be a valid numeric figure and
+    # less than 52, as a season will definitely not last a year.
+    push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.repeat-fixtures-invalid")) if !$fixtures_repeated or $fixtures_repeated !~ m/^\d$/ or $fixtures_repeated < 1;
+  }
   
   if ( scalar( @{$response->{errors}} ) == 0 ) {
     # Generate a URL key
     my $url_key;
     if ( $action eq "edit" ) {
-      $url_key = $self->generate_url_key( $name, $grid->id );
+      $url_key = $class->make_url_key($name, $grid);
     } else {
-      $url_key = $self->generate_url_key( $name );
+      $url_key = $class->make_url_key($name);
     }
-    
-    # Now work out the number of fixtures weeks we'll have.  This is the maximum number of teams per division
-    # (minus 1) multiplied by the number of times a fixture is repeated; for example if teams play each other
-    # team three times and there are a maximum of eight teams per division, number of weeks we will have is:
-    # (8 - 1) * 3 = 21.
-    my $number_of_weeks = ( $maximum_teams - 1 ) * $fixtures_repeated;
-    
-    # Number of matches per divsion per week is the maximum teams per division divided by 2.
-    my $matches_per_week = $maximum_teams / 2;
     
     # Array used to populate multiple rows of data; each row will be a hashref containing the data we wish to insert.
     # This array will be passed as a reference, but keeping it a normal array right now makes the loop more readable.
     my @week_data = ();
     
-    # Loop through all of our weeks building a hashref 
-    for my $i ( 1 .. $number_of_weeks ) {
-      my @matches  = ();
-      # Now loop through the week's matches
-      for my $x ( 1 .. $matches_per_week ) {
-        push(@matches, {match_number => $x,});
-      }
+    if ( $setup_rounds ) {
+      # Now work out the number of fixtures weeks we'll have.  This is the maximum number of teams per division
+      # (minus 1) multiplied by the number of times a fixture is repeated; for example if teams play each other
+      # team three times and there are a maximum of eight teams per division, number of weeks we will have is:
+      # (8 - 1) * 3 = 21.
+      my $number_of_weeks = ( $maximum_teams - 1 ) * $fixtures_repeated;
       
-      # The hashref contains the grid ID and week number; the home and
-      # away team numbers are populated later.  The grid ID is populated in the create
-      push( @week_data, {
-        week => $i,
-        fixtures_grid_matches => \@matches,
-      });
+      # Number of matches per divsion per week is the maximum teams per division divided by 2.
+      my $matches_per_week = $maximum_teams / 2;
+      
+      # Loop through all of our weeks building a hashref 
+      for my $i ( 1 .. $number_of_weeks ) {
+        my @matches  = ();
+        # Now loop through the week's matches
+        for my $x ( 1 .. $matches_per_week ) {
+          push(@matches, {match_number => $x});
+        }
+        
+        # The hashref contains the grid ID and week number; the home and
+        # away team numbers are populated later.  The grid ID is populated in the create
+        push(@week_data, {
+          week => $i,
+          fixtures_grid_matches => \@matches,
+        });
+      }
     }
     
     if ( $action eq "create" ) {
       # Create the grid
-      $grid = $self->create({
+      $grid = $class->create({
         name => $name,
         url_key => $url_key,
         maximum_teams => $maximum_teams,
@@ -373,22 +283,28 @@ sub create_or_edit {
       $response->{completed} = 1;
       push(@{$response->{success}}, $lang->maketext("admin.forms.success", $grid->name, $lang->maketext("admin.message.created")));
     } else {
-      # Delete the grid weeks and matches
-      my @weeks = $grid->fixtures_grid_weeks->all;
-      my @matches = map $_->fixtures_grid_matches->all, @weeks;
-      $_->delete foreach ( @matches );
-      $_->delete foreach ( @weeks );
+      # Set up the update data - name and URL key can always be updated
+      my $update = {name => $name, url_key => $url_key};
+      
+      if ( $setup_rounds ) {
+        # Delete the grid weeks and matches if this isn't a restricted edit
+        my @weeks = $grid->fixtures_grid_weeks->all;
+        my @matches = map $_->fixtures_grid_matches->all, @weeks;
+        $_->delete foreach ( @matches );
+        $_->delete foreach ( @weeks );
+        
+        # Add the max teams / fixtures repeated into the update
+        $update->{maximum_teams} = $maximum_teams;
+        $update->{fixtures_repeated} = $fixtures_repeated;
+      }
       
       # Update the existing grid
-      $grid->update({
-        name => $name,
-        url_key => $url_key,
-        maximum_teams => $maximum_teams,
-        fixtures_repeated => $fixtures_repeated,
-      });
+      $grid->update($update);
       
-      foreach my $week ( @week_data ) {
-        $grid->create_related("fixtures_grid_weeks", $week);
+      if ( $setup_rounds ) {
+        foreach my $week ( @week_data ) {
+          $grid->create_related("fixtures_grid_weeks", $week);
+        }
       }
       
       $response->{completed} = 1;

--- a/lib/TopTable/Schema/ResultSet/LookupGridTeamType.pm
+++ b/lib/TopTable/Schema/ResultSet/LookupGridTeamType.pm
@@ -1,0 +1,21 @@
+package TopTable::Schema::ResultSet::LookupGridTeamType;
+
+use strict;
+use warnings;
+use base 'DBIx::Class::ResultSet';
+
+=head2 all_types
+
+A predefined search for all days of the week returned in day order.
+
+=cut
+
+sub all_types {
+  my ( $self ) = @_;
+  
+  return $self->search(undef, {
+    order_by => {-asc => [qw( display_order )]},
+  });
+}
+
+1;

--- a/lib/TopTable/Schema/ResultSet/Season.pm
+++ b/lib/TopTable/Schema/ResultSet/Season.pm
@@ -407,9 +407,6 @@ sub create_or_edit {
         # Another fatal error
         return $response;
       }
-      
-      # Another fatal error
-      return $response;
     } else {
       push(@{$response->{errors}}, $lang->maketext("seasons.form.error.season-not-specified"));
     }

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -2104,7 +2104,7 @@ msgid "fixtures-grids.matches"
 msgstr "Matches"
 
 msgid "fixtures-grids.positions"
-msgstr "Positions for %1"
+msgstr "League divisional positions for %1"
 
 msgid "fixtures-grid.matches.round"
 msgstr "Round #"
@@ -2121,8 +2121,11 @@ msgstr "Allocate teams to grid numbers"
 msgid "fixtures-grids.teams.error.no-current-season"
 msgstr "You cannot set the teams to their grid numbers as there is no current season; create a new season first."
 
+msgid "fixtures-grids.teams.error.no-divisions-using"
+msgstr "There are no team permissions to set for this grid because no divisions in the current season are using this grid."
+
 msgid "fixtures-grids.teams.error.matches-already-set"
-msgstr "You cannot set the teams to their grid numbers as the fixtures for the current season have already been created."
+msgstr "You cannot set the teams to their grid numbers as the fixtures for this grid in the current season have already been created."
 
 msgid "fixtures-grids.teams.error.no-position-for-team"
 msgstr "%1 %2 has been entered into %3 but has not been listed in a position for the fixtures grid."
@@ -2146,7 +2149,7 @@ msgid "fixtures-grids.form.error.name-blank"
 msgstr "The name field is blank."
 
 msgid "fixtures-grids.form.error.maximum-teams-invalid"
-msgstr "The maximum teams per division field must be an even number between 2 and 98."
+msgstr "The maximum participants per group or division must be an even number between 2 and 98."
 
 msgid "fixtures-grids.form.error.repeat-fixtures-invalid"
 msgstr "The number of times a fixture is repeated must be a number between 1 and 9."
@@ -2155,19 +2158,43 @@ msgid "fixtures-grids.form.matches.cannot-edit"
 msgstr "The matches for this grid can&#39;t be edited because there have been matches created using this template already; you must create a new grid and use that instead."
 
 msgid "fixtures-grids.form.matches.home-team-blank"
-msgstr "The home team for week %1, match %2 is blank."
+msgstr "The home competitor for round %1, match %2 is blank."
 
 msgid "fixtures-grids.form.matches.away-team-blank"
-msgstr "The away team for week %1, match %2 is blank."
+msgstr "The away team for round %1, match %2 is blank."
 
 msgid "fixtures-grids.form.matches.home-number-invalid"
-msgstr "The home team for week %1, match %2 is invalid; it must be a number between 1 and %3."
+msgstr "The home team for round %1, match %2 is invalid; it must be a number between 1 and %3."
 
 msgid "fixtures-grids.form.matches.away-number-invalid"
-msgstr "The home team for week %1, match %2 is invalid; it must be a number between 1 and %3."
+msgstr "The home team for round %1, match %2 is invalid; it must be a number between 1 and %3."
 
-msgid "fixtures-grids.form.matches.team-overused"
-msgstr "In week %1, team %2 is used more than once: (%3).  Please ensure each team is used only once in a given week."
+msgid "fixtures-grids.form.matches.error.team-overused"
+msgstr "In round %1, team %2 is used more than once: (%3).  Please ensure each team is used only once in a given round."
+
+msgid "fixtures-grids.form.matches.error.dynamic-winner-team-overused"
+msgstr "In round %1, the winner of game %2 in the previous round is used more than once (%3).  Please ensure each competitor is used only once in a given round."
+
+msgid "fixtures-grids.form.matches.error.dynamic-loser-team-overused"
+msgstr "In round %1, the loser of game %2 in the previous round is used more than once (%3).  Please ensure each competitor is used only once in a given round."
+
+msgid "fixtures-grids.form.matches.error.team-overused.match-details.home"
+msgstr "match %1 (home)"
+
+msgid "fixtures-grids.form.matches.error.team-overused.match-details.away"
+msgstr "match %1 (away)"
+
+msgid "fixtures-grids.form.matches.type-mismatch-in-match"
+msgstr "The winner / loser has been mixed with the static team / player number in round %1, match %2 - there must be a static competitor, or a dynamic one for both home and away."
+
+msgid "fixtures-grids.form.matches.error-round1-dynamic"
+msgstr "You cannot set winner / loser of the previous round as a competitor in round 1."
+
+msgid "fixtures-grids.form.matches.error.type-mismatch-in-week"
+msgstr "The winner / loser has been mixed with the static team / player number in round %1 - there must be static competitors set for all matches, or a dynamic one."
+
+msgid "fixtures-grids.form.matches.error.invalid-competitor"
+msgstr "There&#39;s an invalid competitor set in round %1, match %2.  Select from the list."
 
 msgid "fixtures-grids.form.matches.success"
 msgstr "The matches for this grid have been set successfully."
@@ -2271,6 +2298,16 @@ msgstr "Player %1"
 msgid "fixtures-grids.form.matches.field.pair-number"
 msgstr "Pair %1"
 
+# %2 because the round number is also passed in here, but only used for dynamic
+msgid "fixtures-grids.form.matches.field.competitor.static"
+msgstr "Team / player %2"
+
+msgid "fixtures-grids.form.matches.field.competitor.dynamic-winner"
+msgstr "Round %1, match %2 winner"
+
+msgid "fixtures-grids.form.matches.field.competitor.dynamic-loser"
+msgstr "Round %1, match %2 loser"
+
 msgid "fixtures-grids.form.teams.bye"
 msgstr "Bye"
 
@@ -2323,7 +2360,7 @@ msgid "fixtures-grids.delete.error.cant-delete"
 msgstr "You cannot delete %1, as it has teams assigned either in this season or in historical seasons."
 
 msgid "fixtures-grids.teams.error.no-current-season"
-msgstr "There is no current season, so teams cannot be set to fixtures grids - create a new season first."
+msgstr "There is no current season, so teams cannot be set to fixtures grids - a new season must be created first, with divsions that use this grid."
 
 msgid "fixtures-grids.teams.error.matches-set"
 msgstr "There are already matches set from this grid in the current season.  If they are incorrect, delete them and then reset the team positions."
@@ -2333,6 +2370,9 @@ msgstr "%s is not a valid team identifier or is in the wrong division."
 
 msgid "fixtures-grids.seasons.count-text"
 msgstr "%1 has been used in %2 %3."
+
+msgid "fixtures-grids.info"
+msgstr "Fixtures grids are used to create matches in any division assigned to that grid, but can also be used for tournament groups."
 
 ### Fixtures and results
 msgid "fixtures-results.title.fixtures-results"
@@ -4587,8 +4627,17 @@ msgstr "Reject on %1"
 msgid "admin.reorder-officials"
 msgstr "Change the display order of league officials"
 
-msgid "admin.fixtures-grid.edit-object"
+msgid "admin.fixtures-grid.set-matches"
 msgstr "Set the matches for %1"
+
+msgid "admin.fixtures-grid.set-positions"
+msgstr "Set the league divisional positions for %1"
+
+msgid "admin.fixtures-grid.create-fixtures"
+msgstr "Create the league fixtures for %1"
+
+msgid "admin.fixtures-grid.delete-fixtures"
+msgstr "Delete the league fixtures for %1"
 
 msgid "admin.form.invalid-action"
 msgstr "Invalid action (%1) passed; the action must be 'create' or 'edit'."

--- a/root/locale/fr.po
+++ b/root/locale/fr.po
@@ -1124,7 +1124,7 @@ msgstr "L'�quipe de la maison pour la semaine %1, match de %2 est invalide; il
 msgid "fixtures-grids.form.matches.away-number-invalid"
 msgstr "L'�quipe visiteuse pour la semaine %1, match de %2 est invalide; il doit �tre un nombre compris entre 1 et %3."
 
-msgid "fixtures-grids.form.matches.team-overused"
+msgid "fixtures-grids.form.matches.error.team-overused"
 msgstr "Dans la semaine %1, l'�quipe %2 est utilis� plus d'une fois: (%3).  S'il vous pla�t assurer que chaque �quipe est utilis� une seule fois dans une semaine donn�e."
 
 msgid "fixtures-grids.form.matches.success"

--- a/root/static/css/main-print.css
+++ b/root/static/css/main-print.css
@@ -517,6 +517,7 @@ form:after {
 div.form-column {
   float: left;
   margin-right: 20px;
+  min-width: 430px;
 }
 
 div.label-field-container, div.label-field-container-weekday, div.label-field-container-multi, div.label-field-container-checkradio {
@@ -1125,7 +1126,7 @@ html[xmlns] .clearfix, html[xmlns] .clear-fix {display: block;}
   }
   
   div.form-column, div.form-column-single {
-    max-width: 300px;
+    max-width: 280px;
     width: 90%;
   }
   
@@ -1180,7 +1181,7 @@ html[xmlns] .clearfix, html[xmlns] .clear-fix {display: block;}
   div.field-container {
     margin-left: 5px;
     width: 100%;
-    max-width: 350px;
+    max-width: 400px;
   	float: left;
   }
   

--- a/root/static/css/main.css
+++ b/root/static/css/main.css
@@ -531,6 +531,7 @@ form:after {
 div.form-column {
   float: left;
   margin-right: 20px;
+  min-width: 430px;
 }
 
 div.label-field-container, div.label-field-container-weekday, div.label-field-container-multi, div.label-field-container-checkradio {
@@ -1139,7 +1140,7 @@ html[xmlns] .clearfix, html[xmlns] .clear-fix {display: block;}
   }
   
   div.form-column, div.form-column-single {
-    max-width: 300px;
+    max-width: 280px;
     width: 90%;
   }
   
@@ -1194,7 +1195,7 @@ html[xmlns] .clearfix, html[xmlns] .clear-fix {display: block;}
   div.field-container {
     margin-left: 5px;
     width: 100%;
-    max-width: 350px;
+    max-width: 400px;
   	float: left;
   }
   

--- a/root/static/script/standard/chosen.js
+++ b/root/static/script/standard/chosen.js
@@ -28,7 +28,7 @@
     $("select.grid-match").chosen({
       single_backstroke_delete: false,
       allow_single_deselect: true,
-      width: "160px"
+      width: "180px"
     });
     
     $("select.average-filter").chosen({

--- a/root/templates/html/fixtures-grids/create-edit.ttkt
+++ b/root/templates/html/fixtures-grids/create-edit.ttkt
@@ -1,3 +1,8 @@
+[%
+IF grid.restricted_edit;
+  SET disabled = ' disabled="disabled"';
+END;
+-%]
 <div id="form">
 <form method="post" action="[% form_action %]">
 <fieldset id="club_details">
@@ -13,7 +18,7 @@
 <div class="label-field-container">
   <label for="maximum_teams">[% c.maketext("fixtures-grids.field.maximum-teams-per-division") %]</label>
   <div class="field-container">
-    <input type="number" id="maximum_teams" name="maximum_teams" min="2" value="[% c.flash.maximum_teams OR grid.maximum_teams %]" />
+    <input type="number" id="maximum_teams" name="maximum_teams" min="2"[% disabled %] value="[% c.flash.maximum_teams OR grid.maximum_teams %]" />
   </div>
   <div class="clear-fix"></div>
 </div>
@@ -21,7 +26,7 @@
 <div class="label-field-container">
   <label for="fixtures_repeated">[% c.maketext("fixtures-grids.field.fixtures-repeated-question") %]</label>
   <div class="field-container">
-    <input type="number" id="fixtures_repeated" name="fixtures_repeated" min="1" value="[% c.flash.fixtures_repeated OR grid.fixtures_repeated %]" />
+    <input type="number" id="fixtures_repeated" name="fixtures_repeated" min="1"[% disabled %] value="[% c.flash.fixtures_repeated OR grid.fixtures_repeated %]" />
   </div>
   <div class="clear-fix"></div>
 </div>

--- a/root/templates/html/fixtures-grids/matches.ttkt
+++ b/root/templates/html/fixtures-grids/matches.ttkt
@@ -1,41 +1,49 @@
+[%
+SET matches_per_round = grid.matches_per_round;
+-%]
 <form method="post" action="[% form_action %]">
 <fieldset>
 <legend>[% c.maketext("fixtures-grids.matches.form.legend.general") %]</legend>
+[%
+IF grid.fixtures_repeated > 1;
+-%]
 <div class="repeat-fixtures">
 [%
-IF c.flash.repeat_fixtures;
-  SET CHECKED = ' checked="checked"';
-  SET REPEAT_DISPLAY = ' style="display: none;"';
-ELSE;
-  SET CHECKED = '';
-  SET REPEAT_DISPLAY = '';
-END;
+  IF c.flash.repeat_fixtures;
+    SET checked = ' checked="checked"';
+    SET repeat_display = ' style="display: none;"';
+  ELSE;
+    SET checked = '';
+    SET repeat_display = '';
+  END;
 -%]
-  <input type="checkbox" id="repeat-fixtures" name="repeat_fixtures" data-label="Repeat fixtures?" value="1"[% CHECKED %] /><br />
+  <input type="checkbox" id="repeat-fixtures" name="repeat_fixtures" data-label="Repeat fixtures?" value="1"[% checked %] /><br />
   <div class="info-message-small">
     <span class="message-text">[% c.maketext("fixtures-grids.form.matches.notice-repeated-fixtures") %]</span>
   </div>
 </div>
 [%
+END;
+
 # Set the number of non-repeated matches (i.e., first pass through) fixtures we have.  This is the maximum number of teams minus 1
 SET first_pass_fixtures = grid.maximum_teams - 1;
 SET first_repeated_week = grid.maximum_teams;
 SET repeated_matches_div_started = 0;
-FOREACH week IN weeks;
+WHILE (week = weeks.next);
   IF week.week > first_pass_fixtures;
-    SET REPEATED_SELECT_CLASS = ' repeated_match';
-    SET DATA_REPEATED = 1;
+    SET repeated_select_case = ' repeated_match';
+    SET data_repeated = 1;
     # If this is the first repeated week, we'll start a new div
     IF week.week == first_repeated_week;
       # Set this flag so we know to close the div at the end
       SET repeated_matches_div_started = 1;
 -%]
-    <div id="repeated-matches"[% REPEAT_DISPLAY %]>
+    <div id="repeated-matches"[% repeat_display %]>
 [%
     END;
   ELSE;
-    SET REPEATED_SELECT_CLASS = '';
-    SET DATA_REPEATED = 0;
+    SET repeated_select_case = '';
+    SET data_repeated = 0;
   END;
 -%]
 <div id="week-[% week.week %]">
@@ -47,27 +55,31 @@ FOREACH week IN weeks;
     SET weeks_array_row = week.week - 1;
     SET matches_array_row = match.match_number - 1;
     
-    IF flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).home_team != "";
-      SET HOME_SELECT_CHECK = flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).home_team;
+    IF flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).home_team.competitor != "";
+      SET home_select_check = flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).home_team.team_grid_type _ "_ " _ flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).home_team.competitor;
     ELSIF match.home_team != "";
-      SET HOME_SELECT_CHECK = match.home_team;
+      # From the database we need to prefix the other part of it - the team grid type (this comes from a different field)
+      # The flashed value above will already have this
+      SET home_select_check = match.home_team_type.id _ "_" _ match.home_team;
     ELSE;
-      SET HOME_SELECT_CHECK = "";
+      SET home_select_check = "";
     END;
     
-    IF flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).away_team != "";
-      SET AWAY_SELECT_CHECK = flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).away_team;
+    IF flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).away_team.competitor != "";
+      SET away_select_check = flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).away_team.team_grid_type _ "_ " _ flashed_weeks.item(weeks_array_row).matches.item(matches_array_row).away_team.competitor;
     ELSIF match.away_team != "";
-      SET AWAY_SELECT_CHECK = match.away_team;
+      # From the database we need to prefix the other part of it - the team grid type (this comes from a different field)
+      # The flashed value above will already have this
+      SET away_select_check = match.away_team_type.id _ "_" _ match.away_team;
     ELSE;
-      SET AWAY_SELECT_CHECK = "";
+      SET away_select_check = "";
     END;
     
     # Extra select class for match number 1
     IF match.match_number == 1;
-      FIRST_MATCH_CLASS = " first_match";
+      first_match_class = " first_match";
     ELSE;
-      FIRST_MATCH_CLASS = "";
+      first_match_class = "";
     END;
     
     SET home_fld = "week_" _ week.week _ "_match_" _ match.match_number _ "_home";
@@ -77,40 +89,72 @@ FOREACH week IN weeks;
   <div class="label-field-container">
     <label for="[% home_fld %]">[% c.maketext("fixtures-grids.matches.field.match-num", match.match_number) %]</label>
     <div class="field-container">
-      <select name="[% home_fld %]" id="[% home_fld %]" data-placeholder="[% c.maketext("fixtures-grids.form.matches.field.match-home-team", match.match_number) %]" data-week="[% week.week %]" data-match="[% match.match_number %]" data-repeated="[% DATA_REPEATED %]" class="grid-match home week[% week.week %] match[% REPEATED_SELECT_CLASS _ FIRST_MATCH_CLASS %]">
-        <option value=""></option>
+        <select name="[% home_fld %]" id="[% home_fld %]" data-placeholder="[% c.maketext("fixtures-grids.form.matches.field.match-home-team", match.match_number) %]" data-week="[% week.week %]" data-match="[% match.match_number %]" data-repeated="[% data_repeated %]" class="grid-match home week[% week.week %] match[% repeated_select_case _ first_match_class %]">
+          <option value=""></option>
 [%
-    SET i = 1;
-    WHILE i <= grid.maximum_teams;
-      # Check if we need to select this option or not
-      IF i == HOME_SELECT_CHECK;
-        SET HOME_SELECTED = ' selected="selected"';
+    # Loop through the team grid types first
+    FOREACH team_type IN grid_team_types;
+      # Then loop through to create each option
+      # We only want the static option if it's the first round (we can't have dynamic options, as they rely on previous round results)
+      LAST IF team_type.id != "static" && week.week == 1;
+      
+      SET i = 1;
+      
+      IF team_type.id == "static";
+        # Static type, loop to the end of the maximum number of teams in a division / group
+        SET loop_end = grid.maximum_teams;
       ELSE;
-        SET HOME_SELECTED = '';
+        # Dynamic type, loop to the end of the number of matches per round
+        SET loop_end = matches_per_round;
       END;
--%]
-        <option value="[% i %]"[% HOME_SELECTED %]>[% c.maketext("fixtures-grids.form.matches.field.team-number", i) %]</option>
-[%
-      SET i = i + 1;
+      
+      WHILE i <= loop_end;
+        # Check if we need to select this option or not
+        IF team_type.id _ "_" _ i == home_select_check;
+          SET home_selected = ' selected="selected"';
+        ELSE;
+          SET home_selected = '';
+        END;
+  -%]
+        <option value="[% team_type.id %]_[% i %]"[% home_selected %]>[% c.maketext("fixtures-grids.form.matches.field.competitor." _ team_type.id, week.week - 1, i) %]</option>
+  [%
+        SET i = i + 1;
+      END;
     END;
 -%]
       </select>
-  [% c.maketext("matches.versus-abbreviation") %]
-      <select name="[% away_fld %]" id="[% away_fld %]" data-placeholder="[% c.maketext("fixtures-grids.form.matches.field.match-away-team", match.match_number) %]" data-week="[% week.week %]" data-match="[% match.match_number %]" data-repeated="[% DATA_REPEATED %]" class="grid-match away week[% week.week %] match[% REPEATED_SELECT_CLASS %]">
+      [% c.maketext("matches.versus-abbreviation") %]
+      <select name="[% away_fld %]" id="[% away_fld %]" data-placeholder="[% c.maketext("fixtures-grids.form.matches.field.match-away-team", match.match_number) %]" data-week="[% week.week %]" data-match="[% match.match_number %]" data-repeated="[% data_repeated %]" class="grid-match away week[% week.week %] match[% repeated_select_case %]">
         <option value=""></option>
 [%
-    SET i = 1;
-    WHILE i <= grid.maximum_teams;
-      # Check if we need to select this option or not
-      IF i == AWAY_SELECT_CHECK;
-        SET AWAY_SELECTED = ' selected="selected"';
+    # Loop through the team grid types first
+    FOREACH team_type IN grid_team_types;
+      # Then loop through to create each option
+      # We only want the static option if it's the first round (we can't have dynamic options, as they rely on previous round results)
+      LAST IF team_type.id != "static" && week.week == 1;
+      
+      SET i = 1;
+      
+      IF team_type.id == "static";
+        # Static type, loop to the end of the maximum number of teams in a division / group
+        SET loop_end = grid.maximum_teams;
       ELSE;
-        SET AWAY_SELECTED = '';
+        # Dynamic type, loop to the end of the number of matches per round
+        SET loop_end = matches_per_round;
       END;
--%]
-        <option value="[% i %]"[% AWAY_SELECTED %]>[% c.maketext("fixtures-grids.form.matches.field.team-number", i) %]</option>
-[%
-      SET i = i + 1;
+      
+      WHILE i <= loop_end;
+        # Check if we need to select this option or not
+        IF team_type.id _ "_" _ i == home_select_check;
+          SET home_selected = ' selected="selected"';
+        ELSE;
+          SET home_selected = '';
+        END;
+  -%]
+        <option value="[% team_type.id %]_[% i %]"[% home_selected %]>[% c.maketext("fixtures-grids.form.matches.field.competitor." _ team_type.id, week.week - 1, i) %]</option>
+  [%
+        SET i = i + 1;
+      END;
     END;
 -%]
       </select>
@@ -129,6 +173,8 @@ FOREACH week IN weeks;
 -%]
 <br />
 [%
+  # Finally set the previous week number, so it can be used on the next iteration
+  SET prev_week = week.week;
 END;
 -%]
 </fieldset>

--- a/root/templates/html/fixtures-grids/view.ttkt
+++ b/root/templates/html/fixtures-grids/view.ttkt
@@ -5,7 +5,13 @@ USE scalar;
   <ul>
     <li><a href="#summary">[% c.maketext("fixtures-grids.summary") %]</a></li>
     <li><a href="#matches">[% c.maketext("fixtures-grids.matches") %]</a></li>
+[%
+IF grid.used_in_league_season(season);
+-%]
     <li><a href="#positions">[% c.maketext("fixtures-grids.positions", enc_season_name) %]</a></li>
+[%
+END;
+-%]
   </ul>
   <div id="summary">
     <div class="table-wrap">
@@ -61,6 +67,9 @@ END;
       </div>
     </div>
   </div>
+[%
+IF grid.used_in_league_season(season);
+-%]
   <div id="positions">
     <div class="table-wrap">
       <div class="table-layout table-layout-centre">
@@ -76,20 +85,20 @@ END;
           </thead>
           <tbody>
 [%
-WHILE (division_season = divisions.next);
-  IF specific_season;
-    SET division_uri = c.uri_for_action("/league-tables/view_specific_season", [division_season.division.url_key, season.url_key]);
-  ELSE;
-    SET division_uri = c.uri_for_action("/league-tables/view_current_season", [division_season.division.url_key]);
-  END;
-  division_name = division_season.name | html_entity;
-  
-  SET last_grid_position = 0;
-  SET team_seasons = division_season.scalar.team_seasons;
-  WHILE (team_season = team_seasons.next);
-    IF team_season.grid_position;
-      IF team_season.grid_position - last_grid_position > 1 AND last_position_set;
-        # We have a bye position, as the current grid position is more than one more than the previous one
+  WHILE (division_season = divisions.next);
+    IF specific_season;
+      SET division_uri = c.uri_for_action("/league-tables/view_specific_season", [division_season.division.url_key, season.url_key]);
+    ELSE;
+      SET division_uri = c.uri_for_action("/league-tables/view_current_season", [division_season.division.url_key]);
+    END;
+    division_name = division_season.name | html_entity;
+    
+    SET last_grid_position = 0;
+    SET team_seasons = division_season.scalar.team_seasons;
+    WHILE (team_season = team_seasons.next);
+      IF team_season.grid_position;
+        IF team_season.grid_position - last_grid_position > 1 AND last_position_set;
+          # We have a bye position, as the current grid position is more than one more than the previous one
       
 -%]
             <tr>
@@ -100,20 +109,20 @@ WHILE (division_season = divisions.next);
               <td data-label="[% c.maketext("fixtures-grid.positions.team-home-night") %]">&nbsp;</td>
             </tr>
 [%
+        END;
+        
+        SET last_grid_position = team_season.grid_position;
+        SET last_position_set = 1;
+      ELSE;
+        SET last_position_set = 0;
       END;
       
-      SET last_grid_position = team_season.grid_position;
-      SET last_position_set = 1;
-    ELSE;
-      SET last_position_set = 0;
-    END;
-    
-    IF specific_season;
-      SET team_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [team_season.club_season.club.url_key, team_season.team.url_key, season.url_key]);
-    ELSE;
-      SET team_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [team_season.club_season.club.url_key, team_season.team.url_key]);
-    END;
-    team_name = team_season.club_season.club.short_name _ " " _ team_season.name | html_entity;
+      IF specific_season;
+        SET team_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [team_season.club_season.club.url_key, team_season.team.url_key, season.url_key]);
+      ELSE;
+        SET team_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [team_season.club_season.club.url_key, team_season.team.url_key]);
+      END;
+      team_name = team_season.club_season.club.short_name _ " " _ team_season.name | html_entity;
     
 -%]
             <tr>
@@ -124,14 +133,18 @@ WHILE (division_season = divisions.next);
               <td data-label="[% c.maketext("fixtures-grid.positions.team-home-night") %]">[% team_season.home_night.weekday_name OR "&nbsp;" %]</td>
             </tr>
 [%
+    END;
   END;
-END;
 -%]
           </tbody>
         </table>
       </div>
     </div>
   </div>
+[%
+# End check for if used in league season
+END;
+-%]
 </div>
 [%
 IF seasons == 1;

--- a/root/templates/html/seasons/create-edit.ttkt
+++ b/root/templates/html/seasons/create-edit.ttkt
@@ -468,11 +468,9 @@ IF restricted_edit != 1;
 END;
 -%]
 
-<div id="rules">
-  <fieldset>
-    <legend>[% c.maketext("seasons.form.rules") %]</legend>
-    <textarea id="rules" name="rules">[% c.flash.rules OR season.rules %]</textarea><br />
-  </fieldset>
-</div>
+<fieldset>
+  <legend>[% c.maketext("seasons.form.rules") %]</legend>
+  <textarea id="rules" name="rules" rows="25" cols="100">[% c.flash.rules OR season.rules %]</textarea><br />
+</fieldset>
 <input type="submit" name="Submit" value="[% c.maketext("form.button.save") %]" />
 </form>


### PR DESCRIPTION
- **[New]** Added the ability for multiple types of fixtures grid team (default is static, which is the current.  The intention is to add dynamic types, so you can select winner / loser of the previous round, not yet implemented properly).
- **[New]** Restricted edit setup on fixtures grids, where if it has matches created already, the name can be edited but nothing else.
- **[New]** New fixtures grid result class method used_in_league_season to check if the grid is used in any divisions in the given season.
- **[New]** Added TopTable::Schema::ResultSet, which can contain methods common to all resultsets.  Current methods are find_url_key, find_id_or_url_key, make_url_key (replacement for generate_url_key), search_single_field (replacement for check_duplicates).
- **[New]** Club and FixturesGrid resultset now inherit from TopTable::Schema::ResultSet (others to follow).
- **[New]** Extended select box width.