### PR TITLE
Matches played today mods

### DIFF
--- a/lib/TopTable/Controller/Root.pm
+++ b/lib/TopTable/Controller/Root.pm
@@ -173,7 +173,7 @@ sub index :Path :Args(0) {
   my $online_users_last_active_limit = $c->datetime_tz({time_zone => "UTC"})->subtract(minutes => 15);
   my $online_user_count = $c->model("DB::Session")->get_online_users({datetime_limit => $online_users_last_active_limit})->count;
   
-  my ( $matches, $matches_today, $matches_started );
+  my ( $matches, $matches_to_show, $matches_started, $next_match_date );
   
   if ( defined($current_season) ) {
     $matches = $c->model("DB::TeamMatch")->matches_on_date({
@@ -182,10 +182,21 @@ sub index :Path :Args(0) {
     });
     
     $matches_started = $matches->matches_started->count;
-    $matches_today = $matches->count;
+    $matches_to_show = $matches->count;
+    
+    if ( !$matches_to_show ) {
+      # No matches today, find the next match date
+      $next_match_date = $c->model("DB::TeamMatch")->next_match_date;
+        $matches = $c->model("DB::TeamMatch")->matches_on_date({
+        season => $current_season,
+        date => $next_match_date,
+      });
+      
+      $matches_to_show = $matches->count;
+    }
   } else {
     $matches_started = 0;
-    $matches_today = 0;
+    $matches_to_show = 0;
   }
   
   my $news_articles_to_show = $c->config->{Index}{news_articles_visible};
@@ -231,8 +242,9 @@ sub index :Path :Args(0) {
     events => \@events,
     exclude_event_user => 1,
     matches => $matches,
-    matches_today => $matches_today,
+    matches_to_show => $matches_to_show,
     matches_started => $matches_started,
+    next_match_date => $next_match_date,
     articles => $articles,
     online_user_count => $online_user_count,
     index_text => $c->model("DB::PageText")->get_text("index"),

--- a/lib/TopTable/Schema/ResultSet/TeamMatch.pm
+++ b/lib/TopTable/Schema/ResultSet/TeamMatch.pm
@@ -3,6 +3,7 @@ package TopTable::Schema::ResultSet::TeamMatch;
 use strict;
 use warnings;
 use base qw( TopTable::Schema::ResultSet );
+use DateTime;
 
 __PACKAGE__->load_components(qw(Helper::ResultSet::SetOperations));
 
@@ -453,6 +454,28 @@ sub matches_in_week {
     "club_season_2.season" => $season->id,
     "scheduled_week.id" => $week->id,
   }, $attrib);
+}
+
+=head2 next_match_date
+
+Get the next date with matches.
+
+=cut
+
+sub next_match_date {
+  my $class = shift;
+  my $schema = $class->result_source->schema;
+  my $dtf = $schema->storage->datetime_parser;
+  
+  my $date = $class->search({
+    played_date => {">=" => DateTime->now->ymd}
+  }, {
+    columns => [{
+      date => {min => "played_date"}
+    }],
+  })->single->get_column("date");
+  
+  return $dtf->parse_date($date);
 }
 
 =head2 matches_on_date

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -429,6 +429,12 @@ msgstr "are"
 msgid "home-page.todays-matches"
 msgstr "Matches playing today"
 
+msgid "home-page.next-matches"
+msgstr "Next matches played: %1 %2 %3"
+
+msgid "home-page.next-matches-year"
+msgstr "Next matches played: %1 %2 %3 %4"
+
 ## Doubles
 msgid "menu.text.doubles"
 msgstr "Doubles"

--- a/root/templates/html/index.ttkt
+++ b/root/templates/html/index.ttkt
@@ -9,8 +9,19 @@ SET table_width = 70;
 INCLUDE "html/event-viewer/view-preloaded.ttkt";
 -%]<br />
 <a href="[% c.uri_for("/event-viewer") %]">[% c.maketext("home-page.updates.view-more") %]</a><br /><br />
+[%
+# If there are matches to show, display as two columns
+IF matches_to_show;
+-%]
 <div class="row">
   <div class="column left">
+[%
+ELSE;
+-%]
+  <div id="news">
+[%
+END;
+-%]
   <h4>[% c.maketext("home-page.news.recent") %]</h4>
 [%
 # Latest news
@@ -18,14 +29,37 @@ INCLUDE "html/news/list.ttkt" index = 1;
 -%]<br />
   <a href="[% c.uri_for("/news") %]">[% c.maketext("home-page.news.view-more") %]</a>.
   </div>
+[%
+# If there are matches to show, display as two columns
+IF matches_to_show;
+-%]
   <div class="column right">
-  <h4>[% c.maketext("home-page.todays-matches") %] ([% matches_today %])</h4>
+[%
+  IF next_match_date;
+    # No matches today, we'll be showing a future date
+    day_name = next_match_date.day_name | ucfirst | html_entity;
+    month_name = next_match_date.month_name | ucfirst | html_entity;
+    
+    IF next_match_date.year == c.datetime.year;
+      SET matches_title = c.maketext("home-page.next-matches", day_name, next_match_date.day, month_name);
+    ELSE;
+      SET matches_title = c.maketext("home-page.next-matches-year", day_name, next_match_date.day, month_name, next_match_date.year);
+    END;
+  ELSE;
+    # Show today's matches
+    SET matches_title = c.maketext("home-page.todays-matches");
+  END;
+%]
+  <h4>[% matches_title %] ([% matches_to_show %])</h4>
 [%
 # Today's matches
 INCLUDE "html/fixtures-results/view-group-divisions-no-date-check-score.ttkt";
 -%]
   </div>
 </div>
+[%
+END;
+-%]
 <br /><br />
 <div id="users_online" class="clear-fix">
 [%


### PR DESCRIPTION
- **[New]** Where no matches are played on today's date, we'll look for the next date with matches and show them (with the appropriate heading) instead.
- **[New]** next_match_date method for TeamMatch resultset to get the next match date (returns a DateTime object).