### PR TITLE
Match score override

### DIFF
--- a/lib/TopTable/Controller/People.pm
+++ b/lib/TopTable/Controller/People.pm
@@ -454,27 +454,6 @@ sub view_seasons :Chained("view") :PathPart("seasons") :Args(0) {
   
   my $seasons = $person->get_seasons;
   
-  # See if we have a count or not
-  my ( $ext_scripts, $ext_styles );
-  if ( $seasons->count ) {
-    $ext_scripts = [
-      $c->uri_for("/static/script/plugins/chosen/chosen.jquery.min.js"),
-      $c->uri_for("/static/script/plugins/datatables/dataTables.min.js"),
-      $c->uri_for("/static/script/plugins/datatables/dataTables.fixedHeader.min.js"),
-      $c->uri_for("/static/script/plugins/datatables/dataTables.responsive.min.js"),
-      $c->uri_for("/static/script/people/seasons.js"),
-    ];
-    $ext_styles = [
-      $c->uri_for("/static/css/chosen/chosen.min.css"),
-      $c->uri_for("/static/css/datatables/dataTables.dataTables.min.css"),
-      $c->uri_for("/static/css/datatables/fixedHeader.dataTables.min.css"),
-      $c->uri_for("/static/css/datatables/responsive.dataTables.min.css"),
-    ];
-  } else {
-    $ext_scripts = [$c->uri_for("/static/script/standard/option-list.js")];
-    $ext_styles = [];
-  }
-  
   # Set up the template to use
   $c->stash({
     template => "html/people/list-seasons-table.ttkt",
@@ -483,8 +462,19 @@ sub view_seasons :Chained("view") :PathPart("seasons") :Args(0) {
     view_online_display => sprintf("Viewing seasons for %s", $person->display_name),
     view_online_link => 1,
     seasons => $seasons,
-    external_scripts => $ext_scripts,
-    external_styles => $ext_styles,
+    external_scripts => [
+      $c->uri_for("/static/script/plugins/chosen/chosen.jquery.min.js"),
+      $c->uri_for("/static/script/plugins/datatables/dataTables.min.js"),
+      $c->uri_for("/static/script/plugins/datatables/dataTables.fixedHeader.min.js"),
+      $c->uri_for("/static/script/plugins/datatables/dataTables.responsive.min.js"),
+      $c->uri_for("/static/script/people/seasons.js", {v => 2}),
+    ],
+    external_styles => [
+      $c->uri_for("/static/css/chosen/chosen.min.css"),
+      $c->uri_for("/static/css/datatables/dataTables.dataTables.min.css"),
+      $c->uri_for("/static/css/datatables/fixedHeader.dataTables.min.css"),
+      $c->uri_for("/static/css/datatables/responsive.dataTables.min.css"),
+    ],
   });
   
   # Push the current URI on to the breadcrumbs

--- a/lib/TopTable/Schema/Result/TeamMatchPlayer.pm
+++ b/lib/TopTable/Schema/Result/TeamMatchPlayer.pm
@@ -475,9 +475,10 @@ sub update_person {
   my $void_unplayed_games_if_both_teams_incomplete = $season->void_unplayed_games_if_both_teams_incomplete;
   my $missing_player_count_win_in_averages = $season->missing_player_count_win_in_averages;
   
-  # First check the match wasn't cancelled; if it was, we return straight away
-  if ( $match->cancelled ) {
-    push(@{$response->{errors}}, $lang->maketext("matches.update.error.match-cancelled"));
+  # Critieria for updating players is the same as that for updating the score
+  my %can = $match->can_update("score");
+  if ( !$can{allowed} ) {
+    push(@{$response->{errors}}, $can{reason});
     return $response;
   }
   

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -777,7 +777,7 @@ msgid "clubs.seasons.season"
 msgstr "Season"
 
 msgid "clubs.seasons.registered-as"
-msgstr "Registered as"
+msgstr "Registered name"
 
 msgid "clubs.none"
 msgstr "There are no clubs to view."
@@ -1108,7 +1108,7 @@ msgid "teams.seasons.count-text"
 msgstr "%1 has been registered in %2 %3."
 
 msgid "teams.seasons.registered-as"
-msgstr "Registered as"
+msgstr "Registered name"
 
 msgid "teams.seasons.club"
 msgstr "Registered for"
@@ -1372,11 +1372,17 @@ msgstr "Membership type"
 msgid "people.field.averages-position"
 msgstr "Averages position"
 
+msgid "people.seasons.registered-as-sort"
+msgstr "Registered name (sortable)"
+
 msgid "people.seasons.registered-as"
-msgstr "Registered as"
+msgstr "Registered name"
 
 msgid "people.summary.registered.active"
 msgstr "Registered team"
+
+msgid "people.seasons.division-sort"
+msgstr "Division (sortable)"
 
 msgid "people.summary.division"
 msgstr "Division"
@@ -1484,7 +1490,10 @@ msgid "people.head-to-head.doubles.error.people-invalid"
 msgstr "Both of the opponent players entered are invalid."
 
 msgid "people.seasons.team"
-msgstr "Registered for"
+msgstr "Registered team"
+
+msgid "people.seasons.division"
+msgstr "Division"
 
 msgid "people.teams.loan"
 msgstr "Played on loan"
@@ -2698,9 +2707,6 @@ msgid "matches.update.games.notice"
 msgstr "Only the first leg fields will be shown to start with; the scores are completed, a valid score will yield the next fields to be filled out.<br />"
 "If the games were played in a different order, you can drag the <span class="ui-icon ui-icon-triangle-2-n-s"></span> icon in the game headings into the correct order."
 
-msgid "matches.update.error.match-cancelled"
-msgstr "This match was cancelled; in order to enter a score, you will need to undo the cancellation first."
-
 msgid "matches.game.header.number"
 msgstr "Game %1"
 
@@ -2763,9 +2769,6 @@ msgstr "Please enter all players before filling out the score for this game."
 
 msgid "matches.game.player-missing-notice"
 msgstr "There are players in this game marked as missing, so you aren&#39;t able to fill out a score for it."
-
-msgid "matches.update.error.season-complete"
-msgstr "You cannot update a match in a season that&#39;s been marked as complete."
 
 msgid "matches.update-playing-order.success"
 msgstr "Game playing order successfully changed."
@@ -2905,6 +2908,9 @@ msgstr "Umpire for game %1 successfully removed."
 msgid "matches.update.error.match-invalid"
 msgstr "The match specified is invalid."
 
+msgid "matches.update.error.match-cancelled"
+msgstr "This match was cancelled; in order to enter a score, you will need to undo the cancellation first."
+
 msgid "matches.update.error.season-complete"
 msgstr "You cannot update a match in a season that&#39;s already been completed."
 
@@ -2913,6 +2919,36 @@ msgstr "The handicap for this match hasn&#39;t been set, so scores cannot be upd
 
 msgid "matches.update.error.handicap-not-set"
 msgstr "Unable to update the score for this handicapped match before the handicap has been set."
+
+msgid "matches.update.error.score-overridden"
+msgstr "The score for this match has been overridden, so the score can't be updated.  Delete the score override before updating."
+
+msgid "matches.update.delete.error.score-overridden"
+msgstr "You cannot delete scores in a match that&#39;s had the score overridden; delete the score override before deleting scores."
+
+msgid "matches.override-score.legend.details"
+msgstr "Override the match score"
+
+msgid "matches.override-score.field.override"
+msgstr "Override the match score"
+
+msgid "matches.override-score.field.scores"
+msgstr "Scores (home / away)"
+
+msgid "matches.override-score.error.cannot-override-score"
+msgstr "The template this match is based on does not allow overriding the score."
+
+msgid "matches.override-score.error.match-not-complete"
+msgstr "The match must be fully completed before the score can be overridden."
+
+msgid "matches.override-score.error.match-cancelled"
+msgstr "You cannot override scores on a cancelled match."
+
+msgid "matches.override-score.info.not-overridden"
+msgstr "The match score was not selected to be overridden, there was nothing to do."
+
+msgid "matches.override-score.error.score-invalid"
+msgstr "The %1 score is invalid; it must be a number greater than 0."
 
 msgid "matches.update-single.error.game-invalid"
 msgstr "The game specified is invalid."
@@ -3012,6 +3048,9 @@ msgstr "This match was cancelled and any match scores showing have been awarded.
 
 msgid "matches.message.info.started-not-complete"
 msgstr "This match scorecard has been started, but is not yet complete."
+
+msgid "matches.message.info.score-overridden"
+msgstr "This match has had the score overridden from the correctly calculated score of %1."
 
 msgid "matches.heading.player-summaries"
 msgstr "Player summaries"
@@ -3208,6 +3247,9 @@ msgstr "Report"
 msgid "matches.cancel.warning.has-score"
 msgstr "This match has already been updated; cancelling the match will remove the existing players and the existing score will be removed from the match and from the tables and averages statistics.  In order to reinstate the score, you will have to undo the cancellation and manually reinput the score."
 
+msgid "matches.cancel.error.started"
+msgstr "This match has already been updated with scores, so can&#39;t be cancelled; delete any scores before cancelling the match."
+
 msgid "matches.cancel.error.season-complete"
 msgstr "You cannot cancel a match in a season that&#39;s been marked as complete."
 
@@ -3248,7 +3290,7 @@ msgid "matches.handicaps.error.not-a-handicapped-match"
 msgstr "This match is not using a template that has a handicap, so handicaps can&#39;t be set."
 
 msgid "matches.handicaps.error.match-started"
-msgstr "The handicaps cannot be updated if the match has some completed scores in."
+msgstr "The handicaps cannot be updated if the match has some completed scores in.  If the handicap needs updating, delete any existing scores first."
 
 msgid "matches.handicaps.error.error.handicap-invalid"
 msgstr "The handicap for %1 is invalid; please enter a number between 0 and 99."
@@ -5023,6 +5065,9 @@ msgstr "Delete %1"
 
 msgid "admin.update-object"
 msgstr "Update %1"
+
+msgid "admin.override-score-object"
+msgstr "Override the score for %1"
 
 msgid "admin.cancel-object"
 msgstr "Cancel %1"
@@ -6855,6 +6900,12 @@ msgstr "Changed the venue for %1%2."
 
 msgid "system-event-log.description.handicap-change"
 msgstr "Changed the handicap for %1%2."
+
+msgid "system-event-log.description.override-score"
+msgstr "Overrode the score for %1%2."
+
+msgid "system-event-log.description.override-score-remove"
+msgstr "Removed the score override for %1%2."
 
 msgid "system-event-log.description.cancel"
 msgstr "Cancelled %1%2."

--- a/root/static/css/main-print.css
+++ b/root/static/css/main-print.css
@@ -563,6 +563,7 @@ button, input, textarea, select {
   font-weight: inherit;
   margin: 3px 0px 0px 0px;
   overflow: visible;
+  font-size: 1em;
 }
 
 input.button-approve {
@@ -597,6 +598,7 @@ input.button-reset {
 
 input[type=radio], input[type=checkbox] {vertical-align: text-bottom;}
 input[type=number] {width:50px;}
+input.wide[type=number] {width:100px; margin-right: 5px;}
 input.date_picker {width: 100px;}
 .ie7 input[type=checkbox] {vertical-align: baseline;}
 label, input[type=submit], input[type=button], input[type=image], button, select {cursor: pointer;}

--- a/root/static/css/main.css
+++ b/root/static/css/main.css
@@ -577,6 +577,7 @@ button, input, textarea, select {
   font-weight: inherit;
   margin: 3px 0px 0px 0px;
   overflow: visible;
+  font-size: 1em;
 }
 
 input.button-approve {
@@ -611,6 +612,7 @@ input.button-reset {
 
 input[type=radio], input[type=checkbox] {vertical-align: text-bottom;}
 input[type=number] {width:50px;}
+input.wide[type=number] {width:100px; margin-right: 5px;}
 input.date_picker {width: 100px;}
 .ie7 input[type=checkbox] {vertical-align: baseline;}
 label, input[type=submit], input[type=button], input[type=image], button, select {cursor: pointer;}

--- a/root/static/script/matches/team/score-override.js
+++ b/root/static/script/matches/team/score-override.js
@@ -1,0 +1,36 @@
+/**
+ *  Handle form fields
+ *
+ */
+$(document).ready(function() {
+  /*
+    Focus on the first available field
+  */
+  if ( $("#override_score").prop("checked") ) {
+    if ( $("home_team_match_score_override").val() === "" ) {
+      $("#home_team_match_score_override").focus();
+    } else if ( $("away_team_match_score_override").val() === "" ) {
+      $("#away_team_match_score_override").focus();
+    } else {
+      $("#home_team_match_score_override").focus();
+    }
+  }
+  
+  set_score_fields();
+  $("#override_score").on("change", set_score_fields);
+  
+  /*
+    Enable / disable text fields based on the checked value of the cancel checkbox
+  */
+  function set_score_fields() {
+    if ( $("#override_score").prop("checked") ) {
+      // Show score fields
+      $("#scores").show();
+    } else {
+      // Show scores fields and blank the values
+      $("#scores").hide();
+      $("#home_team_match_score_override").val("");
+      $("#away_team_match_score_override").val("");
+    }
+  }
+});

--- a/root/static/script/people/seasons.js
+++ b/root/static/script/people/seasons.js
@@ -15,13 +15,19 @@ $(document).ready(function() {
     "order": [1, "desc"],
     "columnDefs": [{
       "visible": false,
-      "targets": [0, 2]
+      "targets": [0, 2, 5]
     }, {
-      "orderData": 1,
-      "targets": 0
+      // Season
+      "orderData": 0,
+      "targets": 1
     }, {
+      // Person name
       "orderData": 3,
       "targets": 2
+    }, {
+      // Division
+      "orderData": 5,
+      "targets": 6
     }]
   });
   

--- a/root/templates/html/clubs/create-edit.ttkt
+++ b/root/templates/html/clubs/create-edit.ttkt
@@ -15,7 +15,6 @@ ELSE;
   SET active_checked = '';
 END;
 -%]
-
 <form method="post" action="[% form_action %]">
 <fieldset>
   <legend>[% c.maketext("clubs.legend.details") %]</legend>

--- a/root/templates/html/clubs/view.ttkt
+++ b/root/templates/html/clubs/view.ttkt
@@ -1,7 +1,5 @@
 [%
-USE scalar;
-
-club_name_html = FILTER html_entity; club_season.full_name; END;
+club_name_html = club_season.full_name | html_entity;
 
 IF club_season;
 %]

--- a/root/templates/html/matches/team/score-override.ttkt
+++ b/root/templates/html/matches/team/score-override.ttkt
@@ -1,0 +1,35 @@
+[%
+IF c.flash.show_flashed;
+  SET home_team_match_score_override = c.flash.home_team_match_score_override;
+  SET away_team_match_score_override = c.flash.away_team_match_score_override;
+  SET override_score = c.flash.override_score;
+ELSE;
+  SET home_team_match_score_override = match.home_team_match_score_override;
+  SET away_team_match_score_override = match.away_team_match_score_override;
+  SET override_score = match.score_overridden;
+END;
+
+IF override_score;
+  SET override_checked = ' checked="checked"';
+ELSE;
+  SET override_checked = '';
+END;
+-%]
+<form method="post" action="[% form_action %]">
+<fieldset>
+  <legend>[% c.maketext("matches.override-score.legend.details") %]</legend>
+  <input type="checkbox" id="override_score" name="override_score" data-label="[% c.maketext("matches.override-score.field.override") %]" value="1"[% override_checked %] />
+  <div class="clear-fix"></div>
+  
+  <div class="label-field-container" id="scores">
+    <label for="home_team_match_score_override">[% c.maketext("matches.override-score.field.scores") %]</label>
+    <div class="field-container">
+      <input type="number" class="wide" id="home_team_match_score_override" name="home_team_match_score_override" value="[% home_team_match_score_override %]" />/
+      <input type="number" class="wide" id="away_team_match_score_override" name="away_team_match_score_override" value="[% away_team_match_score_override %]" />
+    </div>
+    <div class="clear-fix"></div>
+  </div>
+      
+  <input type="submit" id="submit" name="submit" value="[% c.maketext("form.button.save") %]" />
+</fieldset>
+</form>

--- a/root/templates/html/matches/team/update.ttkt
+++ b/root/templates/html/matches/team/update.ttkt
@@ -1,9 +1,8 @@
 [%
 USE Math;
-home_team_html = FILTER html_entity; match.team_season_home_team_season.club_season.short_name _ " " _ match.team_season_home_team_season.name; END;
-away_team_html = FILTER html_entity; match.team_season_away_team_season.club_season.short_name _ " " _ match.team_season_away_team_season.name; END;
+home_team_html = match.team_season_home_team_season.full_name | html_entity;
+away_team_html = match.team_season_away_team_season.full_name | html_entity;
 -%]
-
 <form method="post" action="[% form_action %]">
 <fieldset>
   <legend>[% c.maketext("matches.update.form.legend.match-details") %]</legend>

--- a/root/templates/html/people/list-seasons-table.ttkt
+++ b/root/templates/html/people/list-seasons-table.ttkt
@@ -1,8 +1,3 @@
-[% # This is a TT comment. -%]
-[% # Note That the '-' at the beginning or end of TT code  -%]
-[% # "chomps" the whitespace/newline at that end of the    -%]
-[% # output (use View Source in browser to see the effect) -%]
-[% # Some basic HTML with a loop to display clubs -%]
 [%
 IF seasons.count;
 -%]
@@ -11,38 +6,45 @@ IF seasons.count;
     <table id="datatable" class="stripe hover order-column row-border">
     <thead>
       <tr>
+        <th>[% c.maketext("seasons.list.season-name-sort") %]</th>
         <th>[% c.maketext("seasons.list.season-name") %]</th>
-        <th>[% c.maketext("seasons.list.season-name") %]</th>
-        <th>[% c.maketext("people.seasons.registered-as") %]</th>
+        <th>[% c.maketext("people.seasons.registered-as-sort") %]</th>
         <th>[% c.maketext("people.seasons.registered-as") %]</th>
         <th>[% c.maketext("people.seasons.team") %]</th>
+        <th>[% c.maketext("people.seasons.division-sort") %]</th>
+        <th>[% c.maketext("people.seasons.division") %]</th>
       </tr>
     </thead>
     <tbody>
 [%
   WHILE (person_season = seasons.next);
     IF person_season.season.complete;
-      SET CURRENT_TEXT = "";
+      SET current_text = "";
     ELSE;
-      SET CURRENT_TEXT = " (" _ c.maketext("seasons.text.current") _ ")";
+      SET current_text = " (" _ c.maketext("seasons.text.current") _ ")";
     END;
     
-    SET NAME_SORT = person_season.surname _ ", " _ person_season.first_name;
-    SET TEAM_NAME = person_season.team_season.club_season.short_name _ " " _ person_season.team_season.name;
-    
-    SET SEASON_START = club_season.season.start_date;
-    SET SEASON_END = club_season.season.end_date;
-    CALL SEASON_START.set_locale( c.locale );
-    CALL SEASON_END.set_locale( c.locale );
-    SET SEASON_SORT = SEASON_START("ymd") _ " " _ SEASON_END("ymd");
+    name_sort = person_season.surname _ ", " _ person_season.first_name;
+    SET season = person_season.season;
+    SET season_start = season.start_date;
+    SET season_end = season.end_date;
+    CALL season_start.set_locale(c.locale);
+    CALL season_end.set_locale(c.locale);
+    SET season_sort = season_start("ymd") _ season_end("ymd");
+    SET team_season = person_season.team_season;
+    SET team = team_season.team;
+    SET division_season = team_season.division_season;
+    SET division = division_season.division;
 -%]
 
       <tr>
-        <td>[% SEASON_SORT %]</td>
-        <td><a href="[% c.uri_for_action("/people/view_specific_season", [person.url_key, person_season.season.url_key]) %]">[% person_season.season.name | html_entity %]</a>[% CURRENT_TEXT %]</td>
-        <td>[% NAME_SORT | html_entity %]</td>
-        <td>[% person_season.display_name | html_entity %]</td>
-        <td><a href="[% c.uri_for_action("/teams/view_specific_season_by_url_key", [person_season.team_season.club_season.club.url_key, person_season.team_season.team.url_key, person_season.season.url_key]) %]">[% TEAM_NAME | html_entity %]</a></td>
+        <td data-label="[% c.maketext("seasons.list.season-name-sort") %]">[% season_sort %]</td>
+        <td data-label="[% c.maketext("seasons.list.season-name") %]"><a href="[% c.uri_for_action("/people/view_specific_season", [person.url_key, season.url_key]) %]">[% person_season.season.name | html_entity %]</a>[% current_text %]</td>
+        <td data-label="[% c.maketext("people.seasons.registered-as-sort") %]">[% name_sort | html_entity %]</td>
+        <td data-label="[% c.maketext("people.seasons.registered-as") %]">[% person_season.display_name | html_entity %]</td>
+        <td data-label="[% c.maketext("people.seasons.team") %]"><a href="[% c.uri_for_action("/teams/view_specific_season_by_url_key", [team.club.url_key, team.url_key, season.url_key]) %]">[% person_season.team_season.full_name | html_entity %]</a></td>
+        <td data-label="[% c.maketext("people.seasons.division-sort") %]">[% division.rank %]</td>
+        <td data-label="[% c.maketext("people.seasons.division") %]"><a href="[% c.uri_for_action("/league-averages/view_specific_season", ["singles", division.url_key, season.url_key]) %]">[% division_season.name | html_entity %]</a></td>
       </tr>
 [%
   END;

--- a/root/templates/html/wrappers/responsive.ttkt
+++ b/root/templates/html/wrappers/responsive.ttkt
@@ -84,8 +84,8 @@ END;
 
 <title>[% page_title %]</title>
 
-<link rel="stylesheet" href="[% c.uri_for('/static/css/main.css') %]?v16" type="text/css" media="screen" />
-<link rel="stylesheet" href="[% c.uri_for('/static/css/main-print.css') %]?v16" type="text/css" media="print" />
+<link rel="stylesheet" href="[% c.uri_for('/static/css/main.css') %]?v17" type="text/css" media="screen" />
+<link rel="stylesheet" href="[% c.uri_for('/static/css/main-print.css') %]?v17" type="text/css" media="print" />
 <link rel="stylesheet" href="[% c.uri_for('/static/css/jqueryui/jquery-ui.min.css') %]" type="text/css" media="screen" />
 <link rel="stylesheet" href="[% c.uri_for('/static/css/jqueryui/jquery-ui.structure.min.css') %]" type="text/css" media="screen" />
 <link rel="stylesheet" href="[% c.uri_for('/static/css/jqueryui/jquery-ui.theme.min.css') %]" type="text/css" media="screen" />


### PR DESCRIPTION
- **[New]** Added match score override, for matches using templates that allow it.
- **[New]** New can_update TeamMatch result method to check what we can and can't update or set, and return the reason why not if we can't.
- **[New]** Added group name to the same line as round name in team match headings.
- **[New]** Added division column to person seasons list.
- **[New]** Helper methods on TeamMatch result class - winner_type, allow_final_score_override - shortcut to accessing the match template fields.
- **[New]** TeamMatch result class method team_stats to give us the stats objects to update for this match (which will be the team season for a league match, or tournament and tournament round for a tournament match.
- **[New]** TeamMatch result class method team_score to return the home or away match score, taking into account whether or not the score was overridden.  This should be used to display all scores.