### PR TITLE
Encoding changes

### DIFF
--- a/lib/TopTable.pm
+++ b/lib/TopTable.pm
@@ -83,7 +83,6 @@ __PACKAGE__->config(
     Request => { params => [ qr/password/ ] },
   },
   compression_format => "gzip",
-  encoding => "UTF-8",
 );
 
 

--- a/lib/TopTable/Model/DB.pm
+++ b/lib/TopTable/Model/DB.pm
@@ -7,9 +7,10 @@ __PACKAGE__->config(
     schema_class => 'TopTable::Schema',
     
     connect_info => {
-        dsn => 'dbi:mysql:toptable',
-        user => '',
-        password => '',
+      dsn => 'dbi:mysql:toptable',
+      user => '',
+      password => '',
+      mysql_enable_utf8 => 1
     }
 );
 

--- a/lib/TopTable/View/HTML.pm
+++ b/lib/TopTable/View/HTML.pm
@@ -19,7 +19,6 @@ __PACKAGE__->config(
   TIMER => 0,
   # Wrapper template
   WRAPPER => "html/wrappers/wraparoundthewrapper.ttkt",
-  ENCODING => "utf-8",
 );
 
 =head1 NAME

--- a/root/templates/scripts/ckeditor-iframely-standard.ttkt
+++ b/root/templates/scripts/ckeditor-iframely-standard.ttkt
@@ -15,9 +15,12 @@ FOREACH selector IN ckeditor_selectors;
 
 ClassicEditor
 .create(document.querySelector("#[% selector %]"), {
-[%
+  fontSize: {
+    options: [8, 9, 10, 11, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40]
+  }
+[%-
   IF c.config.Iframely.api_key;
--%]
+-%],
   // Configure 'mediaEmbed' with Iframely previews.
   mediaEmbed: {
     // Previews are always enabled if there’s a provider for a URL (below regex catches all URLs)


### PR DESCRIPTION
- **[New]** Removed encoding params from TopTable config call; the encoding issues were down to DB config (change to toptable.conf, and Catalyst is encoding utf-8 by default, as it should).
- **[New]** Added mysql_enable_utf8 parameter to SQL connection info.
- **[New]** New font size options in CKEditor config to replace spans it was putting in.