### PR TITLE
Improvements to next matches, fix

### DIFF
--- a/lib/TopTable/Schema/Result/TournamentRound.pm
+++ b/lib/TopTable/Schema/Result/TournamentRound.pm
@@ -608,13 +608,11 @@ sub complete {
       # Check if there's another round after this one
       my $next_round = $tourn->find_related("tournament_rounds", {round_number => $round_number + 1});
       
-      if ( defined($next_round) ) {
-        # There's a round after this one, so we're not complete
-        return 0;
-      }
+      # If there's a round after this one, it's complete
+      return 1 if defined($next_round);
       
       # If there's no Check all matches are complete
-      if ( $matches->search({complete => 0})->count == 0 ) {
+      if ( $matches->incomplete_and_not_cancelled->count == 0 ) {
         # All matches are complete
         return 1;
       } else {

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -497,19 +497,22 @@ msgid "home-page.users-online.are"
 msgstr "are"
 
 msgid "home-page.todays-matches"
-msgstr "Today&#39;s matches"
+msgstr "%1 matches playing today"
+
+msgid "home-page.next-matches-tomorrow"
+msgstr "Next matches: %1 tomorrow"
 
 msgid "home-page.next-matches"
-msgstr "Next matches scheduled: %1 %2 %3"
+msgstr "Next matches: %1 on %2 %3 %4"
 
 msgid "home-page.next-matches-year"
-msgstr "Next matches scheduled: %1 %2 %3 %4"
+msgstr "Next matches: %1 on %2 %3 %4 %5"
 
 msgid "home-page.next-match"
-msgstr "Next match scheduled: %1 %2 %3"
+msgstr "Next match: %1 %2 %3"
 
 msgid "home-page.next-match-year"
-msgstr "Next match scheduled: %1 %2 %3 %4"
+msgstr "Next match: %1 %2 %3 %4"
 
 ## Doubles
 msgid "menu.text.doubles"

--- a/root/templates/html/index.ttkt
+++ b/root/templates/html/index.ttkt
@@ -40,17 +40,21 @@ IF matches_to_show;
     day_name = next_match_date.day_name | ucfirst | html_entity;
     month_name = next_match_date.month_name | ucfirst | html_entity;
     
-    IF next_match_date.year == c.datetime.year;
-      SET matches_title = c.maketext("home-page.next-matches", day_name, next_match_date.day, month_name);
+    IF tomorrow;
+      SET matches_title = c.maketext("home-page.next-matches-tomorrow", matches_to_show);
     ELSE;
-      SET matches_title = c.maketext("home-page.next-matches-year", day_name, next_match_date.day, month_name, next_match_date.year);
+      IF next_match_date.year == c.datetime.year;
+        SET matches_title = c.maketext("home-page.next-matches", matches_to_show, day_name, next_match_date.day, month_name);
+      ELSE;
+        SET matches_title = c.maketext("home-page.next-matches-year", matches_to_show, day_name, next_match_date.day, month_name, next_match_date.year);
+      END;
     END;
   ELSE;
     # Show today's matches
-    SET matches_title = c.maketext("home-page.todays-matches");
+    SET matches_title = c.maketext("home-page.todays-matches", matches_to_show);
   END;
 %]
-  <h4>[% matches_title %] ([% matches_to_show %])</h4>
+  <h4>[% matches_title %]</h4>
 [%
 # Today's matches
 INCLUDE "html/fixtures-results/view$handicapped/group-competitions-no-date-check-score.ttkt";


### PR DESCRIPTION
- **[New]** Modifications to next matches playing texts.
- **[New]** If the next matches are tomorrow, we show "tomorrow" rather than the date.
- **[Fix]** Fix to TournamentRound complete routine, which was flagging incomplete if there is a round after this one.