### PR TITLE
Match score logic refined

### DIFF
--- a/lib/TopTable/Schema/Result/TeamMatch.pm
+++ b/lib/TopTable/Schema/Result/TeamMatch.pm
@@ -1492,7 +1492,16 @@ sub score {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   
-  return $self->started ? sprintf("%d-%d", $self->team_score("home"), $self->team_score("away")) : $lang->maketext("matches.versus.not-yet-played");
+  if ( $self->started ) {
+    # If the match is started, return the score regardless
+    return sprintf("%d-%d", $self->team_score("home"), $self->team_score("away"));
+  } else {
+    # If the score hasn't come in yet, we will display either 'not yet played' or 'score not yet received' depending on the date
+    my $today = DateTime->today(time_zone => "UTC");
+    my $cmp = DateTime->compare($self->played_date->truncate(to => "day"), $today->truncate(to => "day"));
+    
+    return $cmp == 1 ? $lang->maketext("matches.versus.not-yet-played") : $lang->maketext("matches.versus.not-yet-received");
+  }
 }
 
 =head2 legs_played

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -2713,8 +2713,11 @@ msgstr "%1 v %2"
 msgid "matches.versus.not-yet-played"
 msgstr "Not yet played"
 
+msgid "matches.versus.not-yet-received"
+msgstr "Not received"
+
 msgid "matches.handicap.not-yet-set"
-msgstr "Handicap not yet set"
+msgstr "Handicap not set"
 
 msgid "matches.handicap.scratch-hcp"
 msgstr "Scratch handicap"
@@ -2726,7 +2729,7 @@ msgid "matches.handicap.format.not-handicapped"
 msgstr "N/A"
 
 msgid "matches.handicap.format.not-set"
-msgstr "Not yet set"
+msgstr "Not set"
 
 msgid "matches.update-score"
 msgstr "Update match date, venue, players and score"

--- a/root/templates/html/fixtures-results/view/by-team.ttkt
+++ b/root/templates/html/fixtures-results/view/by-team.ttkt
@@ -109,7 +109,7 @@ END;
     <td data-label="[% c.maketext("fixtures-results.heading.home-away") %]">[% location_text %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.opponent") %]"><a title="[% opponent_uri_title %]" href="[% opponent_uri %]">[% opponent_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.result") %]">[% match_result.result OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match_result.score OR c.maketext("matches.versus.not-yet-played") %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/fixtures-results/view/group-competitions-no-date-check-score.ttkt
+++ b/root/templates/html/fixtures-results/view/group-competitions-no-date-check-score.ttkt
@@ -83,13 +83,6 @@
         SET comp_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
       END;
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
     <tr>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
@@ -101,7 +94,7 @@
       # If some of the matches have been updated already, show the scores but no venue (this is a space saver, if matches have already)
       # been started we don't really need the venues to show)
 -%]
-      <td><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+      <td><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
 [%
     ELSE;
       # If none of the matches have been updated yet, show the venue but no scores

--- a/root/templates/html/fixtures-results/view/group-competitions-no-date.ttkt
+++ b/root/templates/html/fixtures-results/view/group-competitions-no-date.ttkt
@@ -73,20 +73,13 @@
         SET comp_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
       END;
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
     <tr>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team.full_name | html_entity %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team.full_name | html_entity %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/fixtures-results/view/group-competitions.ttkt
+++ b/root/templates/html/fixtures-results/view/group-competitions.ttkt
@@ -82,13 +82,6 @@
     ELSE;
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [date.year, month, day]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
   <tr>
     <td data-label="[% c.maketext("fixtures-results.heading.day-sort") %]">[% date.day_of_week %]</td>
@@ -99,7 +92,7 @@
     <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel OR match.can_report( c.user );

--- a/root/templates/html/fixtures-results/view/group-week-competitions.ttkt
+++ b/root/templates/html/fixtures-results/view/group-week-competitions.ttkt
@@ -94,13 +94,6 @@
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [played_date.year, played_month, played_day]);
       SET fixtures_week_uri = c.uri_for_action("/fixtures-results/view_week_current_season_end", [week.year, week_month, week_day]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
   <tr>
     <td data-label="[% c.maketext("fixtures-results.heading.week-beginning-sort") %]">[% week.ymd %]</td>
@@ -113,7 +106,7 @@
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(played_date) %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel OR match.can_report( c.user );

--- a/root/templates/html/fixtures-results/view/group-weeks-ordering-no-comp.ttkt
+++ b/root/templates/html/fixtures-results/view/group-weeks-ordering-no-comp.ttkt
@@ -74,13 +74,6 @@
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [date.year, month, day]);
       SET fixtures_week_uri = c.uri_for_action("/fixtures-results/view_week_current_season_end", [week_year, week_month, week_day]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
   <tr>
     <td data-label="[% c.maketext("fixtures-results.heading.week-beginning-sort") %]">[% week.ymd %]</td>
@@ -91,7 +84,7 @@
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/fixtures-results/view/group-weeks-ordering-no-venue.ttkt
+++ b/root/templates/html/fixtures-results/view/group-weeks-ordering-no-venue.ttkt
@@ -89,13 +89,6 @@
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [date.year, month, day]);
       SET fixtures_week_uri = c.uri_for_action("/fixtures-results/view_week_current_season_end", [week_year, week_month, week_day]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
   <tr>
     <td data-label="[% c.maketext("fixtures-results.heading.week-beginning-sort") %]">[% week.ymd %]</td>
@@ -108,7 +101,7 @@
     <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;
 -%]

--- a/root/templates/html/fixtures-results/view/hcp/by-team.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/by-team.ttkt
@@ -111,7 +111,7 @@ END;
     <td data-label="[% c.maketext("fixtures-results.heading.opponent") %]"><a title="[% opponent_uri_title %]" href="[% opponent_uri %]">[% opponent_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.hcp") %]">[% match.relative_handicap(location) %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.result") %]">[% match_result.result OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match_result.score OR c.maketext("matches.versus.not-yet-played") %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/fixtures-results/view/hcp/group-competitions-no-date-check-score.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-competitions-no-date-check-score.ttkt
@@ -85,13 +85,6 @@
         SET comp_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
       END;
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
     <tr>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
@@ -105,7 +98,7 @@
       # If some of the matches have been updated already, show the scores but no venue (this is a space saver, if matches have already)
       # been started we don't really need the venues to show)
 -%]
-      <td><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+      <td><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
 [%
     ELSE;
       # If none of the matches have been updated yet, show the venue but no scores

--- a/root/templates/html/fixtures-results/view/hcp/group-competitions-no-date.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-competitions-no-date.ttkt
@@ -75,13 +75,6 @@
         SET comp_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
       END;
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
     <tr>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
@@ -90,7 +83,7 @@
       <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
-      <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/fixtures-results/view/hcp/group-competitions.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-competitions.ttkt
@@ -84,13 +84,6 @@
     ELSE;
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [date.year, month, day]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
   <tr>
     <td data-label="[% c.maketext("fixtures-results.heading.day-sort") %]">[% date.day_of_week %]</td>
@@ -103,7 +96,7 @@
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel OR match.can_report(c.user);

--- a/root/templates/html/fixtures-results/view/hcp/group-week-competitions.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-week-competitions.ttkt
@@ -92,13 +92,6 @@
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [played_date.year, played_month, played_day]);
       SET fixtures_week_uri = c.uri_for_action("/fixtures-results/view_week_current_season_end", [week.year, week_month, week_day]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
   <tr>
     <td data-label="[% c.maketext("fixtures-results.heading.week-beginning-sort") %]">[% week.ymd %]</td>
@@ -113,7 +106,7 @@
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel OR match.can_report( c.user );

--- a/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering-no-comp.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering-no-comp.ttkt
@@ -76,13 +76,6 @@
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [date.year, month, day]);
       SET fixtures_week_uri = c.uri_for_action("/fixtures-results/view_week_current_season_end", [week_year, week_month, week_day]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
   <tr>
     <td data-label="[% c.maketext("fixtures-results.heading.week-beginning-sort") %]">[% week.ymd %]</td>
@@ -95,7 +88,7 @@
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering-no-venue.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering-no-venue.ttkt
@@ -91,13 +91,6 @@
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [date.year, month, day]);
       SET fixtures_week_uri = c.uri_for_action("/fixtures-results/view_week_current_season_end", [week_year, week_month, week_day]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
   <tr>
     <td data-label="[% c.maketext("fixtures-results.heading.week-beginning-sort") %]">[% week.ymd %]</td>
@@ -112,7 +105,7 @@
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;
 -%]

--- a/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering.ttkt
@@ -99,13 +99,6 @@
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [date.year, month, day]);
       SET fixtures_week_uri = c.uri_for_action("/fixtures-results/view_week_current_season_end", [week_year, week_month, week_day]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
   <tr>
     <td data-label="[% c.maketext("fixtures-results.heading.week-beginning-sort") %]">[% week.ymd %]</td>
@@ -120,7 +113,7 @@
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/fixtures-results/view/hcp/no-grouping.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/no-grouping.ttkt
@@ -84,15 +84,6 @@
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [date.year, month, day]);
     END;
     
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-      #SET scorecard_uri = c.uri_for_action('/matches/team/view_by_url_keys', [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day]);
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-      #SET scorecard_uri = c.uri_for_action('/matches/team/view_by_url_keys', [match.home_team.club.url_key, match.home_team.url_key, match.away_team.club.url_key, match.away_team.url_key, date.year, month, day], undef, \"match-details");
-    END;
-    
     SET date = match.actual_date;
     CALL date.set_locale(c.locale);
 -%]
@@ -107,7 +98,7 @@
       <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
-      <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/fixtures-results/view/no-grouping.ttkt
+++ b/root/templates/html/fixtures-results/view/no-grouping.ttkt
@@ -83,13 +83,6 @@
       SET fixtures_day_uri = c.uri_for_action("/fixtures-results/view_day_current_season_end", [date.year, month, day]);
     END;
     
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
-    
     SET date = match.actual_date;
     CALL date.set_locale(c.locale);
 -%]
@@ -102,7 +95,7 @@
       <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% score %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/people/view.ttkt
+++ b/root/templates/html/people/view.ttkt
@@ -256,7 +256,7 @@ IF teams_count;
           SET result = c.maketext("matches.result.draw");
         END;
       ELSE;
-        SET result = c.maketext("matches.versus.not-yet-played");
+        SET result = c.maketext("matches.versus.not-yet-received");
       END;
 -%]
         <tr[% game_class %]>

--- a/root/templates/html/reports/missing-players.ttkt
+++ b/root/templates/html/reports/missing-players.ttkt
@@ -54,13 +54,6 @@ IF report_data.count;
       SET away_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [away_club, away_team]);
       SET table_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
     <tr>
       <td data-label="[% c.maketext("reports.columns.missing-players.date") %]">[% match.played_date.ymd %]</td>
@@ -70,7 +63,7 @@ IF report_data.count;
       <td data-label="[% c.maketext("reports.columns.missing-players.home-team") %]"><a href="[% home_uri %]">[% home_name | html_entity %]</a></td>
       <td data-label="[% c.maketext("reports.columns.missing-players.away-team") %]"><a href="[% away_uri %]">[% away_name | html_entity %]</a></td>
       <td data-label="[% c.maketext("reports.columns.missing-players.players-missing") %]">[% match.players_absent %]</td>
-      <td data-label="[% c.maketext("reports.columns.missing-players.score-versus") %]"><a href="[% c.uri_for_action("/matches/team/view_by_url_keys", match.url_keys) %]">[% score %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.missing-players.score-versus") %]"><a href="[% c.uri_for_action("/matches/team/view_by_url_keys", match.url_keys) %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("reports.columns.missing-players.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
     </tr>
 [%

--- a/root/templates/html/reports/rearranged-matches.ttkt
+++ b/root/templates/html/reports/rearranged-matches.ttkt
@@ -55,13 +55,6 @@ IF report_data.count;
       SET away_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [away_club, away_team]);
       SET table_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
     END;
-    
-    # Display the score or 'Not yet played'?
-    IF match.home_team_match_score OR match.away_team_match_score;
-      SET score = match.home_team_match_score _ "-" _ match.away_team_match_score;
-    ELSE;
-      SET score = c.maketext("matches.versus.not-yet-played");
-    END;
 -%]
     <tr>
       <td data-label="[% c.maketext("reports.columns.rearranged-matches.scheduled-date") %]">[% match.scheduled_date.ymd("") %]</td>
@@ -72,7 +65,7 @@ IF report_data.count;
       <td data-label="[% c.maketext("reports.columns.rearranged-matches.division") %]"><a href="[% table_uri %]">[% match.division_season.name | html %]</a></td>
       <td data-label="[% c.maketext("reports.columns.rearranged-matches.home-team") %]"><a href="[% home_uri %]">[% home_name | html_entity %]</a></td>
       <td data-label="[% c.maketext("reports.columns.rearranged-matches.away-team") %]"><a href="[% away_uri %]">[% away_name | html_entity %]</a></td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.score-versus") %]"><a href="[% c.uri_for_action("/matches/team/view_by_url_keys", match.url_keys) %]">[% score %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.rearranged-matches.score-versus") %]"><a href="[% c.uri_for_action("/matches/team/view_by_url_keys", match.url_keys) %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("reports.columns.rearranged-matches.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
     </tr>
 [%


### PR DESCRIPTION
- **[New]** Match score logic refined (matches that haven't started yet with dates today or in the past now show 'not received'; future matches show 'not yet played'.  Need to do a flag when the match is postponed and awaiting a date.
- **[New]** Match score logic removed from fixtures and results pages; the score routine is taken directly from the TeamMatch result class.