### PR TITLE
Match postponement, response hash change

### DIFF
--- a/lib/TopTable/Controller/Admin/Bans.pm
+++ b/lib/TopTable/Controller/Admin/Bans.pm
@@ -395,8 +395,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -469,8 +469,8 @@ sub do_delete :Chained("base_item") :PathPart("do-delete") :Args( 0 ) {
   my $response = $ban->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Clubs.pm
+++ b/lib/TopTable/Controller/Clubs.pm
@@ -691,8 +691,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $club->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -734,8 +734,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Events.pm
+++ b/lib/TopTable/Controller/Events.pm
@@ -512,8 +512,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $event->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -1998,8 +1998,8 @@ sub group_do_delete :Chained("groups_current_season") :PathPart("do-delete") :Ar
   my $response = $group->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -2293,8 +2293,8 @@ sub group_do_delete_matches :Chained("groups_current_season") :PathPart("do-dele
   my $response = $group->delete_matches;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -2503,8 +2503,8 @@ sub process_form :Private {
   }
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -2795,8 +2795,8 @@ sub do_edit_details :Chained("base") :PathPart("do-edit-details") :Args(0) {
   my $response = $c->forward(sprintf("do_edit_%s", $event->event_type->id));
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/FixturesGrids.pm
+++ b/lib/TopTable/Controller/FixturesGrids.pm
@@ -576,8 +576,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $grid->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -618,8 +618,8 @@ sub process_form :Private {
     map {$_ => $c->req->params->{$_}} @field_names, # All the fields from the form
   });
   
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -739,8 +739,8 @@ sub set_matches :Chained("base") :PathPart("set-matches") :Args(0) {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -897,8 +897,8 @@ sub set_teams :Chained("base") :PathPart("set-teams") :Args(0) {
   my $response = $grid->set_teams({divisions => \%divisions});
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -1065,8 +1065,8 @@ sub do_create_fixtures :Chained("base") :PathPart("do-create-fixtures") :Args(0)
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -1156,8 +1156,8 @@ sub do_delete_fixtures :Chained("base") :PathPart("do-delete-fixtures") :Args(0)
   my $response = $grid->delete_matches;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Info.pm
+++ b/lib/TopTable/Controller/Info.pm
@@ -77,8 +77,8 @@ sub contact :Local {
   });
   
   # Log our responses
-  $c->log->error($_) foreach @{$banned->{errors}};
-  $c->log->warning($_) foreach @{$banned->{warnings}};
+  $c->log->error($_) foreach @{$banned->{error}};
+  $c->log->warning($_) foreach @{$banned->{warning}};
   $c->log->info($_) foreach @{$banned->{info}};
   
   if ( $banned->{is_banned} ) {
@@ -196,8 +196,8 @@ sub do_contact :Path("send-email") {
   });
   
   # Log our responses
-  $c->log->error($_) foreach @{$banned->{errors}};
-  $c->log->warning($_) foreach @{$banned->{warnings}};
+  $c->log->error($_) foreach @{$banned->{error}};
+  $c->log->warning($_) foreach @{$banned->{warning}};
   $c->log->info($_) foreach @{$banned->{info}};
   
   if ( $banned->{is_banned} ) {

--- a/lib/TopTable/Controller/Info/ContactReasons.pm
+++ b/lib/TopTable/Controller/Info/ContactReasons.pm
@@ -421,8 +421,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $reason->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -465,8 +465,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Info/Officials.pm
+++ b/lib/TopTable/Controller/Info/Officials.pm
@@ -275,8 +275,8 @@ sub do_reorder  :Path("do-reorder") {
   my $response = $c->model("DB::Official")->reorder({official_positions => [split(",", $c->req->params->{official_positions})]});
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Info/Officials/Positions.pm
+++ b/lib/TopTable/Controller/Info/Officials/Positions.pm
@@ -376,8 +376,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $position->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -420,8 +420,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -639,8 +639,8 @@ sub send_email :Chained("holders") :PathPart("send-email") :Args(0) {
   });
   
   # Log our responses
-  $c->log->error($_) foreach @{$banned->{errors}};
-  $c->log->warning($_) foreach @{$banned->{warnings}};
+  $c->log->error($_) foreach @{$banned->{error}};
+  $c->log->warning($_) foreach @{$banned->{warning}};
   $c->log->info($_) foreach @{$banned->{info}};
   
   if ( $banned->{is_banned} ) {

--- a/lib/TopTable/Controller/Info/Privacy.pm
+++ b/lib/TopTable/Controller/Info/Privacy.pm
@@ -110,8 +110,8 @@ sub do_edit :Path("do-edit") :Args(0) {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/LeagueAverages/Filters.pm
+++ b/lib/TopTable/Controller/LeagueAverages/Filters.pm
@@ -436,8 +436,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $filter->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -482,8 +482,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Matches/Team.pm
+++ b/lib/TopTable/Controller/Matches/Team.pm
@@ -177,7 +177,9 @@ sub base :Private {
   });
 }
 
-=head2 view_by_ids
+=head2 view_by_ids, view_by_url_keys
+
+View a team match using the information given in base_by_ids / base_by_url_keys.  Forwards to view.
 
 =cut
 
@@ -185,10 +187,6 @@ sub view_by_ids :Chained("base_by_ids") :PathPart("") :Args(0) {
   my ( $self, $c ) = @_;
   $c->detach("view");
 }
-
-=head2 view_by_url_keys
-
-=cut
 
 sub view_by_url_keys :Chained("base_by_url_keys") :PathPart("") :Args(0) {
   my ( $self, $c ) = @_;
@@ -317,9 +315,9 @@ sub view :Private {
   });
 }
 
-=head2 update_by_ids
+=head2 update_by_ids, update_by_url_keys
 
-Update a team using the information given in base_by_ids
+Update a team using the information given in base_by_ids / base_by_url_keys.  Forwards to update.
 
 =cut
 
@@ -327,12 +325,6 @@ sub update_by_ids :Chained("base_by_ids") :PathPart("update") :Args(0) {
   my ( $self, $c ) = @_;
   $c->detach("update");
 }
-
-=head2 update_by_url_keys
-
-Update a team using the information given in base_by_ids
-
-=cut
 
 sub update_by_url_keys :Chained("base_by_url_keys") :PathPart("update") :Args(0) {
   my ( $self, $c ) = @_;
@@ -424,9 +416,9 @@ sub update :Private {
   });
 }
 
-=head2 do_update_by_ids
+=head2 do_update_by_ids, do_update_by_url_keys
 
-Chained to base_by_ids and provides the path for updating a match.
+Chained to base_by_ids / base_by_url_keys and provides the path for updating a match.  Forwards to do_update.
 
 =cut
 
@@ -434,12 +426,6 @@ sub do_update_by_ids :Chained("base_by_ids") :PathPart("do-update") {
   my ( $self, $c ) = @_;
   $c->detach("do_update");
 }
-
-=head2 do_update_by_url_keys
-
-Chained to base_by_url_keys and provides the path for updating a match.
-
-=cut
 
 sub do_update_by_url_keys :Chained("base_by_url_keys") :PathPart("do-update") {
   my ( $self, $c ) = @_;
@@ -463,7 +449,7 @@ sub do_update :Private {
   
   my $update_result = $match->update_scorecard($params);
   
-  if ( scalar @{$update_result->{errors}} ) {
+  if ( scalar @{$update_result->{error}} ) {
     
   } else {
     # Log an update
@@ -473,9 +459,9 @@ sub do_update :Private {
   }
 }
 
-=head2 update_game_score_by_ids
+=head2 update_game_score_by_ids, update_game_score_by_url_keys
 
-Provides the URL for update_game_score by chaining to base_by_ids; forwards to the real routine.
+Provides the URL for update_game_score by chaining to base_by_ids / base_by_url_keys respectively; forwards to update_game_score.
 
 =cut
 
@@ -483,12 +469,6 @@ sub update_game_score_by_ids :Chained("base_by_ids") :PathPart("game-score") Arg
   my ( $self, $c ) = @_;
   $c->detach("update_game_score");
 }
-
-=head2 update_game_score_by_url_keys
-
-Provides the URL for update_game_score by chaining to base_by_ids; forwards to the real routine.
-
-=cut
 
 sub update_game_score_by_url_keys :Chained("base_by_url_keys") :PathPart("game-score") Args(0) {
   my ( $self, $c ) = @_;
@@ -513,8 +493,8 @@ sub update_game_score :Private {
   my $response = $match->update_scorecard($params);
   
   # Set the status messages we need to show back to the user
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my @match_scores = @{$response->{match_scores}};
@@ -526,6 +506,7 @@ sub update_game_score :Private {
       match_originally_complete => $response->{match_originally_complete},
       match_complete => $response->{match_complete},
       match_scores => \@match_scores,
+      postponed => $match->postponed,
     }
   });
   
@@ -553,9 +534,9 @@ sub update_game_score :Private {
   return;
 }
 
-=head2 update_js_by_ids
+=head2 update_js_by_ids, update_js_by_url_keys
 
-Generate the javascript for updating a scorecard based on the information given in base_by_ids
+Generate the javascript for updating a scorecard based on the information given in base_by_ids / base_by_url_keys.  Forwards to update_js.
 
 =cut
 
@@ -563,12 +544,6 @@ sub update_js_by_ids :Chained("base_by_ids") :PathPart("update.js") :Args(0) {
   my ( $self, $c ) = @_;
   $c->detach("update_js");
 }
-
-=head2 update_js_by_url_keys
-
-Update a team using the information given in base_by_ids
-
-=cut
 
 sub update_js_by_url_keys :Chained("base_by_url_keys") :PathPart("update.js") :Args(0) {
   my ( $self, $c ) = @_;
@@ -600,9 +575,9 @@ sub update_js :Private {
   $c->detach($c->view("HTML"));
 }
 
-=head2 calculate_running_scores_by_ids
+=head2 calculate_running_scores_by_ids, calculate_running_scores_by_url_keys
 
-Return the running scores for each game based on the information given in base_by_ids.
+Return the running scores for each game based on the information given in base_by_ids / base_by_url_keys.  Forwards to calculate_running_scores.
 
 =cut
 
@@ -610,12 +585,6 @@ sub calculate_running_scores_by_ids :Chained("base_by_ids") :PathPart("calculate
   my ( $self, $c ) = @_;
   $c->detach("calculate_running_scores");
 }
-
-=head2 calculate_running_scores_by_url_keys
-
-Return the running scores for each game based on the information given in base_by_ids.
-
-=cut
 
 sub calculate_running_scores_by_url_keys :Chained("base_by_url_keys") :PathPart("calculate-running-scores") :Args(0) {
   my ( $self, $c ) = @_;
@@ -642,9 +611,67 @@ sub calculate_running_scores :Private {
   return;
 }
 
-=head2 change_played_date_by_ids
+=head2 set_postponed_by_ids, set_postponed_by_url_keys
 
-Provides a URL for change_played_date by chaining to base_by_ids; forwards to the real routine.
+Receive the postponed flag for a match based on the information given in base_by_ids / base_by_url_keys.  Forwards to set_postponed.
+
+=cut
+
+sub set_postponed_by_ids :Chained("base_by_ids") :PathPart("set-postponed") :Args(0) {
+  my ( $self, $c ) = @_;
+  $c->detach("set_postponed");
+}
+
+sub set_postponed_by_url_keys :Chained("base_by_url_keys") :PathPart("set-postponed") :Args(0) {
+  my ( $self, $c ) = @_;
+  $c->detach("set_postponed");
+}
+
+=head2 set_postponed
+
+Receive and set the postponed flag for a match.
+
+=cut
+
+sub set_postponed :Private {
+  my ( $self, $c ) = @_;
+  my $match = $c->stash->{match};
+  my $postponed = $c->req->params->{postponed};
+  
+  # Check that we are authorised to update scorecards
+  $c->forward("TopTable::Controller::Users", "check_authorisation", ["match_update", $c->maketext("user.auth.update-matches"), 1]);
+  my $response = $match->set_postponed($postponed, {logger => sub{ my $level = shift; $c->log->$level( @_ ); },});
+  
+  # Set the status messages we need to show back to the user
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
+  my @info = @{$response->{info}};
+  my @success = @{$response->{success}};
+  
+  # Stash the messages
+  $c->stash({json_data => {messages => {error => \@errors, warning => \@warnings, info => \@info, success => \@success}}});
+  
+  if ( $response->{completed} ) {
+    # Completed, log that we updated the match
+    my $match_name = $c->maketext("matches.name", $match->team_season_home_team_season->full_name, $match->team_season_away_team_season->full_name);
+    $match_name .= " (" . $match->tournament_round->tournament->event_season->name . ")" if defined($match->tournament_round);
+    
+    my $action = $postponed ? "postpone" : "postpone-unset";
+    $c->forward("TopTable::Controller::SystemEventLog", "add_event", ["team-match", $action, {home_team => $match->team_season_home_team_season->team->id, away_team => $match->team_season_away_team_season->team->id, scheduled_date => $match->scheduled_date->ymd}, $match_name]);
+  } else {
+    # Wasn't completed, return with an error code
+    $c->log->debug(np($response));
+    $c->res->status(400);
+  }
+  
+  # Detach to the JSON view
+  $c->detach($c->view("JSON"));
+  return;
+}
+
+=head2 change_played_date_by_ids, change_played_date_by_url_keys
+
+Provides URLs for change_played_date by chaining to base_by_ids aznd base_by_url_keys respectively; forwards to the change_played_date.
 
 =cut
 
@@ -652,12 +679,6 @@ sub change_played_date_by_ids  :Chained("base_by_ids") :PathPart("change-date") 
   my ( $self, $c ) = @_;
   $c->detach("change_played_date");
 }
-
-=head2 change_played_date_by_url_keys
-
-Provides a URL for change_played_date by chaining to base_by_ids; forwards to the real routine.
-
-=cut
 
 sub change_played_date_by_url_keys  :Chained("base_by_url_keys") :PathPart("change-date") Args(0) {
   my ( $self, $c ) = @_;
@@ -685,13 +706,13 @@ sub change_played_date :Private {
   my $response = $match->update_played_date($cldr->parse_datetime($c->req->params->{date}));
   
   # Set the status messages we need to show back to the user
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   
   # Stash the messages
-  $c->stash({json_data => {messages => {error => \@errors, warning => \@warnings, info => \@info, success => \@success}}});
+  $c->stash({json_data => {messages => {error => \@errors, warning => \@warnings, info => \@info, success => \@success}, postponed => $match->postponed}});
   
   if ( $response->{completed} ) {
     # Completed, log that we updated the match
@@ -708,9 +729,9 @@ sub change_played_date :Private {
   return;
 }
 
-=head2 change_venue_by_ids
+=head2 change_venue_by_ids, change_venue_by_url_keys
 
-Provides the change_venue URL chaining to base_by_ids, then forwards to the real routine
+Provides the change_venue URL chaining to base_by_ids / base_by_url_keys respectively; forwards to change_venue.
 
 =cut
 
@@ -718,12 +739,6 @@ sub change_venue_by_ids :Chained("base_by_ids") :PathPart("change-venue") Args(0
   my ( $self, $c )  = @_;
   $c->detach("change_venue");
 }
-
-=head2 change_venue_by_url_keys
-
-Provides the change_venue URL chaining to base_by_ids, then forwards to the real routine
-
-=cut
 
 sub change_venue_by_url_keys :Chained("base_by_url_keys") :PathPart("change-venue") Args(0) {
   my ( $self, $c )  = @_;
@@ -747,8 +762,8 @@ sub change_venue :Private {
   my $response = $match->update_venue($c->req->params->{venue});
   
   # Set the status messages we need to show back to the user
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   
@@ -770,9 +785,9 @@ sub change_venue :Private {
   return;
 }
 
-=head2 get_player_lists_by_ids
+=head2 get_player_lists_by_ids, get_player_lists_by_url_keys
 
-Provides the URL for get_playerlists by chaining to base_by_ids.  Forwards to the real routine.
+Provides the URL for get_playerlists by chaining to base_by_ids / base_by_url_keys respectively; forwards to get_player_lists.
 
 =cut
 
@@ -780,12 +795,6 @@ sub get_player_lists_by_ids :Chained("base_by_ids") :PathPart("player-lists") Ar
   my ( $self, $c ) = @_;
   $c->detach("get_player_lists");
 }
-
-=head2 get_player_lists_by_url_keys
-
-Provides the URL for get_playerlists by chaining to base_by_ids.  Forwards to the real routine.
-
-=cut
 
 sub get_player_lists_by_url_keys :Chained("base_by_url_keys") :PathPart("player-lists") Args(0) {
   my ( $self, $c ) = @_;
@@ -849,9 +858,9 @@ sub get_player_lists :Private {
   return;
 }
 
-=head2 update_playing_order_by_ids
+=head2 update_playing_order_by_ids, update_playing_order_by_url_keys
 
-Provides the URL for update_playing_order chaining to base_by_ids; forwards to the real routine.
+Provides the URL for update_playing_order chaining to base_by_ids / base_by_url_keys respectively; forwards to update_playing_order.
 
 =cut
 
@@ -859,12 +868,6 @@ sub update_playing_order_by_ids :Chained("base_by_ids") :PathPart("playing-order
   my ( $self, $c ) = @_;
   $c->detach("update_playing_order");
 }
-
-=head2 update_playing_order_by_url_keys
-
-Provides the URL for update_playing_order chaining to base_by_ids; forwards to the real routine.
-
-=cut
 
 sub update_playing_order_by_url_keys :Chained("base_by_url_keys") :PathPart("playing-order") Args(0) {
   my ( $self, $c ) = @_;
@@ -881,8 +884,8 @@ sub update_playing_order :Private {
   my $response = $match->update_playing_order($c->req->params);
   
   # Set the status messages we need to show back to the user
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my @match_scores = @{$response->{match_scores}};
@@ -903,9 +906,9 @@ sub update_playing_order :Private {
   return;
 }
 
-=head2 cancel_by_ids
+=head2 cancel_by_ids, cancel_by_url_keys
 
-Provides the URL for cancel chaining to base_by_ids; forwards to the real routine.
+Provides the URL for cancel chaining to base_by_ids / base_by_url_keys respectively; forwards to cancel.
 
 =cut
 
@@ -913,12 +916,6 @@ sub cancel_by_ids :Chained("base_by_ids") :PathPart("cancel") Args(0) {
   my ( $self, $c ) = @_;
   $c->detach("cancel");
 }
-
-=head2 cancel_by_url_keys
-
-Provides the URL for cancel chaining to base_by_ids; forwards to the real routine.
-
-=cut
 
 sub cancel_by_url_keys :Chained("base_by_url_keys") :PathPart("cancel") Args(0) {
   my ( $self, $c ) = @_;
@@ -985,9 +982,9 @@ sub cancel :Private {
   });
 }
 
-=head2 do_cancel_by_ids
+=head2 do_cancel_by_ids, do_cancel_by_url_keys
 
-Provides the URL for do_cancel chaining to base_by_ids; forwards to the real routine.
+Provides the URL for do_cancel chaining to base_by_ids / base_by_url_keys respectively; forwards to do_cancel.
 
 =cut
 
@@ -995,12 +992,6 @@ sub do_cancel_by_ids :Chained("base_by_ids") :PathPart("do-cancel") Args(0) {
   my ( $self, $c ) = @_;
   $c->detach("do_cancel");
 }
-
-=head2 do_cancel_by_url_keys
-
-Provides the URL for cancel chaining to base_by_ids; forwards to the real routine.
-
-=cut
 
 sub do_cancel_by_url_keys :Chained("base_by_url_keys") :PathPart("do-cancel") Args(0) {
   my ( $self, $c ) = @_;
@@ -1030,8 +1021,8 @@ sub do_cancel :Private {
     : $match->uncancel;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -1107,7 +1098,7 @@ sub override_score :Private {
     # Not allowed to override, get the reason and redirect
     # Redirect with the correct message if we can't override
     $c->response->redirect($c->uri_for_action("/matches/team/view_by_url_keys", $match->url_keys,
-      {mid => $c->set_status_msg({error => $can_override{reason}})}));
+      {mid => $c->set_status_msg({$can_override{level} => $can_override{reason}})}));
     $c->detach;
     return;
   }
@@ -1172,8 +1163,8 @@ sub do_override_score :Private {
   });
   
   # Set the status messages we need to show back to the user
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -1211,9 +1202,9 @@ sub do_override_score :Private {
   return;
 }
 
-=head2 report_by_ids
+=head2 report_by_ids, report_by_url_keys
 
-Report on a match using the information given in base_by_ids
+Report on a match using the information given in base_by_ids / base_by_url_keys.  Forwards to report.
 
 =cut
 
@@ -1221,12 +1212,6 @@ sub report_by_ids :Chained("base_by_ids") :PathPart("report") :Args(0) {
   my ( $self, $c ) = @_;
   $c->detach("report");
 }
-
-=head2 report_by_url_keys
-
-Report on a match using the information given in base_by_ids
-
-=cut
 
 sub report_by_url_keys :Chained("base_by_url_keys") :PathPart("report") :Args(0) {
   my ( $self, $c ) = @_;
@@ -1267,9 +1252,9 @@ sub report :Private {
   });
 }
 
-=head2 publish_report_by_ids
+=head2 publish_report_by_ids, publish_report_by_url_keys
 
-Report on a match using the information given in base_by_ids
+Publish a submitted report on a match using the information given in base_by_ids / base_by_url_keys.  Forwards to publish_report.
 
 =cut
 
@@ -1277,12 +1262,6 @@ sub publish_report_by_ids :Chained("base_by_ids") :PathPart("publish-report") :A
   my ( $self, $c ) = @_;
   $c->detach("publish_report");
 }
-
-=head2 publish_report_by_url_keys
-
-Report on a match using the information given in base_by_ids
-
-=cut
 
 sub publish_report_by_url_keys :Chained("base_by_url_keys") :PathPart("publish-report") :Args(0) {
   my ( $self, $c ) = @_;
@@ -1310,8 +1289,8 @@ sub publish_report :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -1406,9 +1385,9 @@ sub check_report_create_edit_authorisation :Private {
   });
 }
 
-=head2 change_handicaps_by_ids
+=head2 change_handicaps_by_ids, change_handicap_by_url_keys
 
-Provides the change_handicap URL chaining to base_by_ids, then forwards to the real routine
+Provides the change_handicap URL chaining to base_by_ids / base_by_url_keys respectively, then forwards to the real routine.
 
 =cut
 
@@ -1416,12 +1395,6 @@ sub change_handicaps_by_ids :Chained("base_by_ids") :PathPart("handicaps") Args(
   my ( $self, $c )  = @_;
   $c->detach("change_handicaps");
 }
-
-=head2 change_handicap_by_url_keys
-
-Provides the change_venue URL chaining to base_by_ids, then forwards to the real routine
-
-=cut
 
 sub change_handicaps_by_url_keys :Chained("base_by_url_keys") :PathPart("handicaps") Args(0) {
   my ( $self, $c )  = @_;
@@ -1446,7 +1419,7 @@ sub change_handicaps :Private {
   my %can_change = $match->can_update("handicaps");
   if ( !$can_change{allowed} ) {
     $c->response->redirect($c->uri_for_action("/matches/team/view_by_url_keys", $match->url_keys,
-                                {mid => $c->set_status_msg({error => $can_change{reason}})}));
+                                {mid => $c->set_status_msg({$can_change{level} => $can_change{reason}})}));
     $c->detach;
     return;
   }
@@ -1469,9 +1442,9 @@ sub change_handicaps :Private {
   });
 }
 
-=head2 set_handicaps_by_ids
+=head2 set_handicaps_by_ids, set_handicap_by_url_keys
 
-Provides the set_handicap URL chaining to base_by_ids, then forwards to the real routine
+Provides the set_handicap URL chaining to base_by_ids / base_by_url_keys.  Forwards to set_handicaps.
 
 =cut
 
@@ -1479,12 +1452,6 @@ sub set_handicaps_by_ids :Chained("base_by_ids") :PathPart("set-handicaps") Args
   my ( $self, $c )  = @_;
   $c->detach("set_handicaps");
 }
-
-=head2 set_handicap_by_url_keys
-
-Provides the change_venue URL chaining to base_by_ids, then forwards to the real routine
-
-=cut
 
 sub set_handicaps_by_url_keys :Chained("base_by_url_keys") :PathPart("set-handicaps") Args(0) {
   my ( $self, $c )  = @_;
@@ -1508,7 +1475,7 @@ sub set_handicaps :Private {
   my %can_change = $match->can_update("handicaps");
   if ( !$can_change{allowed} ) {
     $c->response->redirect($c->uri_for_action("/matches/team/view_by_url_keys", $match->url_keys,
-                                {mid => $c->set_status_msg({error => $can_change{reason}})}));
+                                {mid => $c->set_status_msg({$can_change{level} => $can_change{reason}})}));
     $c->detach;
     return;
   }
@@ -1520,8 +1487,8 @@ sub set_handicaps :Private {
   });
   
   # Set the status messages we need to show back to the user
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Matches/Team/Game.pm
+++ b/lib/TopTable/Controller/Matches/Team/Game.pm
@@ -138,8 +138,8 @@ sub doubles_pair :Private {
   });
   
   # Set the status messages we need to show back to the user
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   
@@ -198,8 +198,8 @@ sub reset_score :Private {
   });
   
   # Set the status messages we need to show back to the user
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my @match_scores = @{$response->{match_scores}};

--- a/lib/TopTable/Controller/Matches/Team/Player.pm
+++ b/lib/TopTable/Controller/Matches/Team/Player.pm
@@ -159,8 +159,8 @@ sub update :Private {
   });
   
   # Set the status messages we need to show back to the user
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my @match_scores = @{$response->{match_scores}};

--- a/lib/TopTable/Controller/MeetingTypes.pm
+++ b/lib/TopTable/Controller/MeetingTypes.pm
@@ -425,8 +425,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $meeting_type->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -468,8 +468,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Meetings.pm
+++ b/lib/TopTable/Controller/Meetings.pm
@@ -740,8 +740,8 @@ sub do_delete :Private {
   my $response = $meeting->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -807,8 +807,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/News.pm
+++ b/lib/TopTable/Controller/News.pm
@@ -547,8 +547,8 @@ sub do_delete :Private {
   my $response = $article->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -608,8 +608,8 @@ sub process_form :Private {
   my $response = $c->model("DB::NewsArticle")->create_or_edit($action, $params);
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/People.pm
+++ b/lib/TopTable/Controller/People.pm
@@ -1167,8 +1167,8 @@ sub do_delete :Chained("base") :Path("do-delete") :Args(0) {
   my $response = $person->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -1226,8 +1226,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -1357,8 +1357,8 @@ sub import_results :Path("import-results") {
         date_format => $c->i18n_datetime_format_date->pattern,
       });
       
-      my @errors = @{$response->{errors}};
-      my @warnings = @{$response->{warnings}};
+      my @errors = @{$response->{error}};
+      my @warnings = @{$response->{warning}};
       my @info = @{$response->{info}};
       my @success = @{$response->{success}};
       my @successful_rows = @{$response->{successful_rows}};
@@ -1442,8 +1442,8 @@ sub transfer :Chained("base") :PathPart("transfer") :Args(0) {
   my $season = $response->{fields}{season};
   my $to_person = $response->{fields}{to_person};
   
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Roles.pm
+++ b/lib/TopTable/Controller/Roles.pm
@@ -457,8 +457,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $role->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -505,8 +505,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Root.pm
+++ b/lib/TopTable/Controller/Root.pm
@@ -121,8 +121,8 @@ sub begin :Private {
   });
   
   # Log our responses
-  $c->log->error($_) foreach @{$banned->{errors}};
-  $c->log->warning($_) foreach @{$banned->{warnings}};
+  $c->log->error($_) foreach @{$banned->{error}};
+  $c->log->warning($_) foreach @{$banned->{warning}};
   $c->log->info($_) foreach @{$banned->{info}};
   
   if ( $banned->{is_banned} ) {
@@ -306,8 +306,8 @@ sub do_index_edit :Path("do-index-edit") :Args(0) {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Seasons.pm
+++ b/lib/TopTable/Controller/Seasons.pm
@@ -573,8 +573,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $season->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -656,8 +656,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -773,8 +773,8 @@ sub do_archive :Chained("base") :PathPart("do-archive") :Args(0) {
     my $response = $season->check_and_complete;
     
     # Set the status messages we need to show on redirect
-    my @errors = @{$response->{errors}};
-    my @warnings = @{$response->{warnings}};
+    my @errors = @{$response->{error}};
+    my @warnings = @{$response->{warning}};
     my @info = @{$response->{info}};
     my @success = @{$response->{success}};
     my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Teams.pm
+++ b/lib/TopTable/Controller/Teams.pm
@@ -676,8 +676,8 @@ sub send_email_captain :Private {
   });
   
   # Log our responses
-  $c->log->error($_) foreach @{$banned->{errors}};
-  $c->log->warning($_) foreach @{$banned->{warnings}};
+  $c->log->error($_) foreach @{$banned->{error}};
+  $c->log->warning($_) foreach @{$banned->{warning}};
   $c->log->info($_) foreach @{$banned->{info}};
   
   if ( $banned->{is_banned} ) {
@@ -1468,8 +1468,8 @@ sub do_delete :Private {
   my $response = $team->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -1566,8 +1566,8 @@ sub process_form :Private {
   
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Templates/LeagueTableRanking.pm
+++ b/lib/TopTable/Controller/Templates/LeagueTableRanking.pm
@@ -389,8 +389,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $tt_template->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -432,8 +432,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Templates/Match/Individual.pm
+++ b/lib/TopTable/Controller/Templates/Match/Individual.pm
@@ -410,8 +410,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $tt_template->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -453,8 +453,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Templates/Match/Team.pm
+++ b/lib/TopTable/Controller/Templates/Match/Team.pm
@@ -422,8 +422,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $tt_template->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -465,8 +465,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -605,8 +605,8 @@ sub set_games :Chained("base") :PathPart("set-games") :Args(0) {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Controller/Users.pm
+++ b/lib/TopTable/Controller/Users.pm
@@ -346,8 +346,8 @@ sub register :Global {
     });
     
     # Log our responses
-    $c->log->error($_) foreach @{$banned->{errors}};
-    $c->log->warning($_) foreach @{$banned->{warnings}};
+    $c->log->error($_) foreach @{$banned->{error}};
+    $c->log->warning($_) foreach @{$banned->{warning}};
     $c->log->info($_) foreach @{$banned->{info}};
     
     if ( $banned->{is_banned} ) {
@@ -516,8 +516,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -633,8 +633,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $user->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -673,8 +673,8 @@ sub regenerate_activation_key :Chained("base") :PathPart("regenerate-activation-
   my $response = $user->regenerate_activation_key({activation_expiry_limit => $activation_expiry_limit});
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $redirect_uri = $c->uri_for("/", {mid => $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success})});
@@ -752,8 +752,8 @@ sub activate :Chained("base") :PathPart("activate") :Args(1) {
     });
     
     # Set the status messages we need to show on redirect
-    my @errors = @{$response->{errors}};
-    my @warnings = @{$response->{warnings}};
+    my @errors = @{$response->{error}};
+    my @warnings = @{$response->{warning}};
     my @info = @{$response->{info}};
     my @success = @{$response->{success}};
     my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -929,8 +929,8 @@ sub bulk_approval :Path("bulk-approval") :Args(0) {
         
         my $response = $c->forward("approve");
         
-        my @user_errors = @{$response->{errors}};
-        my @user_warnings = @{$response->{warnings}};
+        my @user_errors = @{$response->{error}};
+        my @user_warnings = @{$response->{warning}};
         my @user_info = @{$response->{info}};
         my @user_success = @{$response->{success}};
         
@@ -996,8 +996,8 @@ sub approve :Chained("base") :PathPart("approve") :Args(0) {
     });
     
     # Set the status messages we need to show on redirect
-    my @errors = @{$response->{errors}};
-    my @warnings = @{$response->{warnings}};
+    my @errors = @{$response->{error}};
+    my @warnings = @{$response->{warning}};
     my @info = @{$response->{info}};
     my @success = @{$response->{success}};
     my $redirect_uri;
@@ -1062,8 +1062,8 @@ sub approve :Chained("base") :PathPart("approve") :Args(0) {
     });
     
     # Set the status messages we need to show on redirect
-    my @errors = @{$response->{errors}};
-    my @warnings = @{$response->{warnings}};
+    my @errors = @{$response->{error}};
+    my @warnings = @{$response->{warning}};
     my @info = @{$response->{info}};
     my @success = @{$response->{success}};
     my $redirect_uri;
@@ -1116,8 +1116,8 @@ sub login :Global {
     });
     
     # Log our responses
-    $c->log->error($_) foreach @{$banned->{errors}};
-    $c->log->warning($_) foreach @{$banned->{warnings}};
+    $c->log->error($_) foreach @{$banned->{error}};
+    $c->log->warning($_) foreach @{$banned->{warning}};
     $c->log->info($_) foreach @{$banned->{info}};
     
     if ( $banned->{is_banned} ) {
@@ -1280,8 +1280,8 @@ sub do_login :Path("authenticate") {
         });
         
         # Log our responses
-        $c->log->error($_) foreach @{$banned->{errors}};
-        $c->log->warning($_) foreach @{$banned->{warnings}};
+        $c->log->error($_) foreach @{$banned->{error}};
+        $c->log->warning($_) foreach @{$banned->{warning}};
         $c->log->info($_) foreach @{$banned->{info}};
         
         if ( $banned->{is_banned} ) {
@@ -1504,8 +1504,8 @@ sub send_reset_link :Path("send-reset-link") {
       
       # If we've got this far, we've passed the CAPTCHA (or it was disabled), so we set a password reset link
       my $response = $user->set_password_reset_key;
-      push(@errors, @{$response->{errors}});
-      push(@warnings, @{$response->{warnings}});
+      push(@errors, @{$response->{error}});
+      push(@warnings, @{$response->{warning}});
       push(@info, @{$response->{info}});
       push(@success, @{$response->{success}});
       
@@ -1633,8 +1633,8 @@ sub reset_password :Chained("base") :PathPart("reset-password") :Args(1) {
       logger => sub{ my $level = shift; $c->log->$level( @_ ); },
     });
     
-    my @errors = @{$response->{errors}};
-    my @warnings = @{$response->{warnings}};
+    my @errors = @{$response->{error}};
+    my @warnings = @{$response->{warning}};
     my @info = @{$response->{info}};
     my @success = @{$response->{success}};
     

--- a/lib/TopTable/Controller/Venues.pm
+++ b/lib/TopTable/Controller/Venues.pm
@@ -500,8 +500,8 @@ sub do_delete :Chained("base") :PathPart("do-delete") :Args(0) {
   my $response = $venue->check_and_delete;
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});
@@ -547,8 +547,8 @@ sub process_form :Private {
   });
   
   # Set the status messages we need to show on redirect
-  my @errors = @{$response->{errors}};
-  my @warnings = @{$response->{warnings}};
+  my @errors = @{$response->{error}};
+  my @warnings = @{$response->{warning}};
   my @info = @{$response->{info}};
   my @success = @{$response->{success}};
   my $mid = $c->set_status_msg({error => \@errors, warning => \@warnings, info => \@info, success => \@success});

--- a/lib/TopTable/Model/Geocode.pm
+++ b/lib/TopTable/Model/Geocode.pm
@@ -100,8 +100,8 @@ sub search {
   my $reverse = $params->{reverse} || 0;
   my $loc_param = $reverse ? "latlng" : "address";
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     results => [],
@@ -119,7 +119,7 @@ sub search {
   my $res = $self->ua->get($url);
   
   if ( $res->is_error ) {
-    push(@{$response->{errors}}, $lang->maketext("google.maps.geocode.errors", $res->status_line, $res->message));
+    push(@{$response->{error}}, $lang->maketext("google.maps.geocode.errors", $res->status_line, $res->message));
     return $response;
   }
   

--- a/lib/TopTable/Schema/Result/AverageFilter.pm
+++ b/lib/TopTable/Schema/Result/AverageFilter.pm
@@ -274,8 +274,8 @@ sub check_and_delete{
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -284,7 +284,7 @@ sub check_and_delete{
   # Check we can delete
   my $enc_name = encode_entities($self->name);
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("average-filters.delete.error.cannot-delete", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("average-filters.delete.error.cannot-delete", $enc_name));
     return $response;
   }
   
@@ -296,7 +296,7 @@ sub check_and_delete{
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $enc_name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $enc_name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/Ban.pm
+++ b/lib/TopTable/Schema/Result/Ban.pm
@@ -282,8 +282,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -291,7 +291,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("admin.bans.delete.error.cannot-delete", $self->banned_id));
+    push(@{$response->{error}}, $lang->maketext("admin.bans.delete.error.cannot-delete", $self->banned_id));
     return $response;
   }
   
@@ -304,7 +304,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/BannedUser.pm
+++ b/lib/TopTable/Schema/Result/BannedUser.pm
@@ -279,8 +279,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -288,7 +288,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("lubs.delete.error.cannot-delete", $self->banned_id->username));
+    push(@{$response->{error}}, $lang->maketext("lubs.delete.error.cannot-delete", $self->banned_id->username));
     return $response;
   }
   
@@ -301,7 +301,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/Club.pm
+++ b/lib/TopTable/Schema/Result/Club.pm
@@ -411,8 +411,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -423,7 +423,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("clubs.delete.error.cannot-delete", $name));
+    push(@{$response->{error}}, $lang->maketext("clubs.delete.error.cannot-delete", $name));
     return $response;
   }
   
@@ -435,7 +435,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/ContactReason.pm
+++ b/lib/TopTable/Schema/Result/ContactReason.pm
@@ -189,8 +189,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -199,7 +199,7 @@ sub check_and_delete {
   # Check we can delete
   my $enc_name = encode_entities($self->name);
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("contact-reasons.delete.error.cannot-delete", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("contact-reasons.delete.error.cannot-delete", $enc_name));
     return $response;
   }
   
@@ -211,7 +211,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $enc_name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $enc_name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/Event.pm
+++ b/lib/TopTable/Schema/Result/Event.pm
@@ -247,8 +247,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -256,7 +256,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("events.delete.error.cannot-delete", $self->name));
+    push(@{$response->{error}}, $lang->maketext("events.delete.error.cannot-delete", $self->name));
     return $response;
   }
   
@@ -269,7 +269,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/EventSeason.pm
+++ b/lib/TopTable/Schema/Result/EventSeason.pm
@@ -450,8 +450,8 @@ sub _set_meeting_details {
   
   # Set the response hash up
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {
@@ -472,7 +472,7 @@ sub _set_meeting_details {
   # Now check if we have anyone who appears on both lists
   if ( scalar(@{$people->{conflict}}) == 1 ) {
     # One person on both lists elicits a different message to multiple people
-    push(@{$response->{errors}}, $lang->maketext("meetings.form.error.attendee-on-both-lists", encode_entities($people->{conflict}[0]->display_name)));
+    push(@{$response->{error}}, $lang->maketext("meetings.form.error.attendee-on-both-lists", encode_entities($people->{conflict}[0]->display_name)));
   } elsif ( scalar(@{$people->{conflict}}) > 1 ) {
     # Multiple people on both lists, get their names and encode them for the error message
     # Save the number of conflicts, as we'll be popping the last one off here to build the message, so we need to get the total number early on
@@ -486,12 +486,12 @@ sub _set_meeting_details {
     
     my $conflict_people = sprintf("%s %s %s", join(", ", @people_names), $lang->maketext("msg.and"), $last);
     
-    push(@{$response->{errors}}, $lang->maketext("meetings.form.error.attendees-on-both-lists", $conflicts, $conflict_people));
+    push(@{$response->{error}}, $lang->maketext("meetings.form.error.attendees-on-both-lists", $conflicts, $conflict_people));
   }
   
   # Check for invalid attendees / apologies
-  push(@{$response->{errors}}, $lang->maketext("meetings.form.error.attendees-invalid", $people->{attendees}{invalid})) if $people->{attendees}{invalid};
-  push(@{$response->{errors}}, $lang->maketext("meetings.form.error.apologies-invalid", $people->{apologies}{invalid})) if $people->{apologies}{invalid};
+  push(@{$response->{error}}, $lang->maketext("meetings.form.error.attendees-invalid", $people->{attendees}{invalid})) if $people->{attendees}{invalid};
+  push(@{$response->{error}}, $lang->maketext("meetings.form.error.apologies-invalid", $people->{apologies}{invalid})) if $people->{apologies}{invalid};
   
   # Start a transaction so we don't have a partially updated database
   my $transaction = $self->result_source->schema->txn_scope_guard;

--- a/lib/TopTable/Schema/Result/MeetingType.pm
+++ b/lib/TopTable/Schema/Result/MeetingType.pm
@@ -175,8 +175,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -184,7 +184,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("meeting-types.delete.error.not-allowed", $self->name));
+    push(@{$response->{error}}, $lang->maketext("meeting-types.delete.error.not-allowed", $self->name));
     return $response;
   }
   
@@ -197,7 +197,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/NewsArticle.pm
+++ b/lib/TopTable/Schema/Result/NewsArticle.pm
@@ -393,8 +393,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -402,7 +402,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("news.delete.error.cannot-delete", encode_entities($self->current_details->{headline})));
+    push(@{$response->{error}}, $lang->maketext("news.delete.error.cannot-delete", encode_entities($self->current_details->{headline})));
     return $response;
   }
   
@@ -418,7 +418,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", encode_entities($name), $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", encode_entities($name)));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", encode_entities($name)));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/Official.pm
+++ b/lib/TopTable/Schema/Result/Official.pm
@@ -208,8 +208,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -220,7 +220,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("officials.delete.error.cannot-delete", $name));
+    push(@{$response->{error}}, $lang->maketext("officials.delete.error.cannot-delete", $name));
     return $response;
   }
   
@@ -236,7 +236,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/Person.pm
+++ b/lib/TopTable/Schema/Result/Person.pm
@@ -1310,8 +1310,8 @@ sub transfer_statistics {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1334,11 +1334,11 @@ sub transfer_statistics {
     if ( defined($to_person) ) {
       $response->{fields}{to_person} = $to_person;
     } else {
-      push(@{$response->{errors}}, $lang->maketext("people.transfer.to-person-invalid"));
+      push(@{$response->{error}}, $lang->maketext("people.transfer.to-person-invalid"));
     }
   } else {
     # Blank
-    push(@{$response->{errors}}, $lang->maketext("people.transfer.to-person-blank"));
+    push(@{$response->{error}}, $lang->maketext("people.transfer.to-person-blank"));
   }
   
   if ( defined($season) ) {
@@ -1349,14 +1349,14 @@ sub transfer_statistics {
     if ( defined($season) ) {
       $response->{fields}{season} = $season;
     } else {
-      push(@{$response->{errors}}, $lang->maketext("people.transfer.season-invalid"));
+      push(@{$response->{error}}, $lang->maketext("people.transfer.season-invalid"));
     }
   } else {
     # Blank
-    push(@{$response->{errors}}, $lang->maketext("people.transfer.season-blank"));
+    push(@{$response->{error}}, $lang->maketext("people.transfer.season-blank"));
   }
   
-  if ( scalar @{$response->{errors}} == 0 ) {
+  if ( scalar @{$response->{error}} == 0 ) {
     # Search the "to" person to make sure they have no current season statistics.
     my $memberships = $self->result_source->schema->resultset("PersonSeason")->get_person_season_and_teams_and_divisions({
       person => $to_person,
@@ -1365,7 +1365,7 @@ sub transfer_statistics {
     })->count;
     
     if ( $memberships ) {
-      push(@{$response->{errors}}, $lang->maketext("people.transfer.has-memberhsips"));
+      push(@{$response->{error}}, $lang->maketext("people.transfer.has-memberhsips"));
     } else {
       # No errors, now search for memberships to transfer
       my @memberships = $self->result_source->schema->resultset("PersonSeason")->get_person_season_and_teams_and_divisions({
@@ -1445,7 +1445,7 @@ sub transfer_statistics {
         $response->{completed} = 1;
         push(@{$response->{success}}, $lang->maketext("people.transfer.success"));
       } else {
-        push(@{$response->{errors}}, $lang->maketext("people.transfer.nothing-to-transfer"));
+        push(@{$response->{error}}, $lang->maketext("people.transfer.nothing-to-transfer"));
       }
     }
   }
@@ -1529,8 +1529,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1541,7 +1541,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("people.delete.error.not-allowed", $name));
+    push(@{$response->{error}}, $lang->maketext("people.delete.error.not-allowed", $name));
     return $response;
   }
   
@@ -1562,7 +1562,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/Role.pm
+++ b/lib/TopTable/Schema/Result/Role.pm
@@ -1643,8 +1643,8 @@ sub set_members {
   
   # Setup the response
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1655,7 +1655,7 @@ sub set_members {
   
   # Check we're not modifying the memberlist of the 'registered users' group, as every user is automatically a member of this and can't be removed
   if ( $self->apply_on_registration ) {
-    push(@{$response->{errors}}, $lang->maketext("roles.form.notice.cant-modify-registered-users-members"));
+    push(@{$response->{error}}, $lang->maketext("roles.form.notice.cant-modify-registered-users-members"));
     return $response;
   }
   
@@ -1687,7 +1687,7 @@ sub set_members {
   }
   
   # Warn if we had invalid users
-  push(@{$response->{warnings}}, $lang->maketext("roles.form.warning.users-invalid", $invalid_members)) if $invalid_members;
+  push(@{$response->{warning}}, $lang->maketext("roles.form.warning.users-invalid", $invalid_members)) if $invalid_members;
   
   # Now get a list of the current members and map them so they're just IDs
   my @current_members = $self->members;
@@ -1717,7 +1717,7 @@ sub set_members {
     # The final list of members will be a combination of new and existing members
     my @new_full_member_list = ( @new_members, @existing_members );
     if ( scalar @new_full_member_list == 0 ) {
-      push(@{$response->{errors}}, $lang->maketext("roles.form.error.cant-remove-all-sysadmins"));
+      push(@{$response->{error}}, $lang->maketext("roles.form.error.cant-remove-all-sysadmins"));
       return $response;
     }
   }
@@ -1744,7 +1744,7 @@ sub set_members {
     push(@{$response->{success}}, $lang->maketext("admin.forms.roles.set-members.success"));
   } else {
     # Not updated, error
-    push(@{$response->{errors}}, $lang->maketext("admin.update.errror.database.roles-set"));
+    push(@{$response->{error}}, $lang->maketext("admin.update.errror.database.roles-set"));
   }
   
   return $response;
@@ -1776,8 +1776,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1788,7 +1788,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("roles.delete.error.cannot-delete"));
+    push(@{$response->{error}}, $lang->maketext("roles.delete.error.cannot-delete"));
     return $response;
   }
   
@@ -1800,7 +1800,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/Season.pm
+++ b/lib/TopTable/Schema/Result/Season.pm
@@ -723,8 +723,8 @@ sub check_and_complete {
   # Encode the name for messaging
   my $enc_name = encode_entities($self->name);
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -732,24 +732,24 @@ sub check_and_complete {
   
   # Check we can complete
   if ( $self->complete ) {
-    push(@{$response->{errors}}, $lang->maketext("seasons.complete.error.season-complete", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("seasons.complete.error.season-complete", $enc_name));
     return $response;
   }
   
   if ( $schema->resultset("TeamMatch")->incomplete_and_not_cancelled({season => $self})->count > 0 ) {
-    push(@{$response->{errors}}, $lang->maketext("seasons.complete.error.matches-incomplete", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("seasons.complete.error.matches-incomplete", $enc_name));
     return $response;
   }
   
   # Delete
-  my $ok = $self->update({complete => 1}) if scalar @{$response->{errors}} == 0;
+  my $ok = $self->update({complete => 1}) if scalar @{$response->{error}} == 0;
   
   # Error if the delete was unsuccessful
   if ( $ok ) {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("seasons.complete.success", $enc_name));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("seasons.complete.error.database", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("seasons.complete.error.database", $enc_name));
   }
   
   return $response;
@@ -804,15 +804,15 @@ sub check_and_delete {
   # Encode the name for messaging
   my $enc_name = encode_entities($self->name);
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
   };
   
   # Check we can delete
-  push(@{$response->{errors}}, $lang->maketext("seasons.delete.error.matches-exist", $enc_name)) unless $self->can_delete;
+  push(@{$response->{error}}, $lang->maketext("seasons.delete.error.matches-exist", $enc_name)) unless $self->can_delete;
   
   # Order of the first three is important; person seasons must come before team seasons, which must come before club seasons
   my @relations = qw( person_seasons team_seasons club_seasons division_seasons doubles_pairs event_seasons fixtures_weeks );
@@ -824,7 +824,7 @@ sub check_and_delete {
     $ok = $self->delete_related($relation);
     
     # Error if the delete was unsuccessful
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $enc_name, ref($relation))) unless $ok;
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $enc_name, ref($relation))) unless $ok;
   }
   
   # Delete
@@ -835,7 +835,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $enc_name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $enc_name, ref($self)));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $enc_name, ref($self)));
   }
   
   $transaction->commit;

--- a/lib/TopTable/Schema/Result/Team.pm
+++ b/lib/TopTable/Schema/Result/Team.pm
@@ -562,8 +562,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -574,7 +574,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("clubs.delete.error.cannot-delete", $name));
+    push(@{$response->{error}}, $lang->maketext("clubs.delete.error.cannot-delete", $name));
     return $response;
   }
   
@@ -597,7 +597,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;
@@ -621,8 +621,8 @@ sub adjust_points {
   my $lang = $schema->lang;
   
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -638,10 +638,10 @@ sub adjust_points {
     if ( defined($team_season) ) {
       $response = $team_season->adjust_points($params);
     } else {
-      push(@{$response->{errors}}, $lang->maketext("tables.adjustments.error.team-not-entered-season", encode_entities($self->full_name)));
+      push(@{$response->{error}}, $lang->maketext("tables.adjustments.error.team-not-entered-season", encode_entities($self->full_name)));
     }
   } else {
-    push(@{$response->{errors}}, $lang->maketext("tables.adjustments.error.no-current-season"));
+    push(@{$response->{error}}, $lang->maketext("tables.adjustments.error.no-current-season"));
   }
 }
 

--- a/lib/TopTable/Schema/Result/TeamSeason.pm
+++ b/lib/TopTable/Schema/Result/TeamSeason.pm
@@ -1008,8 +1008,8 @@ sub adjust_points {
   my $reason = $params->{reason} || undef;
   
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1024,7 +1024,7 @@ sub adjust_points {
   my $season = $self->season;
   
   if ( $season->complete ) {
-    push @{$response->{errors}}, $lang->maketext("tables.adjustments.error.season-not-current", encode_entities($season->name));
+    push @{$response->{error}}, $lang->maketext("tables.adjustments.error.season-not-current", encode_entities($season->name));
     return $response;
   }
   
@@ -1032,19 +1032,19 @@ sub adjust_points {
   $response->{can_complete} = 1;
   
   # Check our fields
-  push(@{$response->{errors}}, $lang->maketext("tables.adjustments.error.invalid-action")) unless defined($action) and ($action eq "award" or $action eq "deduct");
+  push(@{$response->{error}}, $lang->maketext("tables.adjustments.error.invalid-action")) unless defined($action) and ($action eq "award" or $action eq "deduct");
   
   if ( $points_adjustment =~ m/^[1-9]+$/ ) {
     # Points adjustment is fine, set it into the fields to be passed back
     $response->{fields}{points_adjustment} = $points_adjustment;
   } else {
     # Points adjustment is invalid
-    push(@{$response->{errors}}, $lang->maketext("tables.adjustments.error.invalid-points-adjustment"));
+    push(@{$response->{error}}, $lang->maketext("tables.adjustments.error.invalid-points-adjustment"));
   }
   
-  push(@{$response->{errors}}, $lang->maketext("tables.adjustments.error.blank-reason")) unless defined($reason) and length($reason) > 0;
+  push(@{$response->{error}}, $lang->maketext("tables.adjustments.error.blank-reason")) unless defined($reason) and length($reason) > 0;
   
-  if ( scalar @{$response->{errors}} == 0 ) {
+  if ( scalar @{$response->{error}} == 0 ) {
     # No errors, do the update
     # First get the ranking template in use
     my $division_season = $self->division_season;

--- a/lib/TopTable/Schema/Result/TemplateLeagueTableRanking.pm
+++ b/lib/TopTable/Schema/Result/TemplateLeagueTableRanking.pm
@@ -224,8 +224,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -235,7 +235,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_edit_or_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("templates.delete.error.not-allowed", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("templates.delete.error.not-allowed", $enc_name));
     return $response;
   }
   
@@ -247,7 +247,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $enc_name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $enc_name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/TemplateMatchIndividual.pm
+++ b/lib/TopTable/Schema/Result/TemplateMatchIndividual.pm
@@ -329,8 +329,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -340,7 +340,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_edit_or_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("templates.delete.error.not-allowed", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("templates.delete.error.not-allowed", $enc_name));
     return $response;
   }
   
@@ -352,7 +352,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $enc_name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $enc_name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/TemplateMatchTeam.pm
+++ b/lib/TopTable/Schema/Result/TemplateMatchTeam.pm
@@ -331,8 +331,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -342,7 +342,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_edit_or_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("templates.delete.error.not-allowed", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("templates.delete.error.not-allowed", $enc_name));
     return $response;
   }
   
@@ -354,7 +354,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $enc_name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $enc_name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $enc_name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/Result/TournamentRoundTeam.pm
+++ b/lib/TopTable/Schema/Result/TournamentRoundTeam.pm
@@ -837,8 +837,8 @@ sub adjust_points {
   my $reason = $params->{reason} || undef;
   
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -854,7 +854,7 @@ sub adjust_points {
   my %can = $self->tournament_team->can_update("points");
   
   unless ( $can{allowed} ) {
-    push(@{$response->{errors}}, $can{reason});
+    push(@{$response->{error}}, $can{reason});
     return $response;
   }
   
@@ -862,19 +862,19 @@ sub adjust_points {
   $response->{can_complete} = 1;
   
   # Check our fields
-  push(@{$response->{errors}}, $lang->maketext("tournament.team.update.points.error.invalid-action")) unless defined($action) and ($action eq "award" or $action eq "deduct");
+  push(@{$response->{error}}, $lang->maketext("tournament.team.update.points.error.invalid-action")) unless defined($action) and ($action eq "award" or $action eq "deduct");
   
   if ( $points_adjustment =~ m/^[1-9]+$/ ) {
     # Points adjustment is fine, set it into the fields to be passed back
     $response->{fields}{points_adjustment} = $points_adjustment;
   } else {
     # Points adjustment is invalid
-    push(@{$response->{errors}}, $lang->maketext("tournament.team.update.error.invalid-points-adjustment"));
+    push(@{$response->{error}}, $lang->maketext("tournament.team.update.error.invalid-points-adjustment"));
   }
   
-  push(@{$response->{errors}}, $lang->maketext("tournament.team.update.error.blank-reason")) unless defined($reason) and length($reason) > 0;
+  push(@{$response->{error}}, $lang->maketext("tournament.team.update.error.blank-reason")) unless defined($reason) and length($reason) > 0;
   
-  if ( scalar @{$response->{errors}} == 0 ) {
+  if ( scalar @{$response->{error}} == 0 ) {
     # No errors, do the update
     # First get the ranking template in use
     my $group = $self->tournament_group;

--- a/lib/TopTable/Schema/Result/TournamentTeam.pm
+++ b/lib/TopTable/Schema/Result/TournamentTeam.pm
@@ -879,8 +879,8 @@ sub adjust_points {
   my $lang = $schema->lang;
   
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -891,7 +891,7 @@ sub adjust_points {
   my %can = $self->can_update("points");
   
   unless ( $can{allowed} ) {
-    push(@{$response->{errors}}, $can{reason});
+    push(@{$response->{error}}, $can{reason});
     return $response;
   }
   
@@ -905,7 +905,7 @@ sub adjust_points {
   if ( defined($tourn_round_team) ) {
     $response = $tourn_round_team->adjust_points($params);
   } else {
-    push(@{$response->{errors}}, $lang->maketext("tables.adjustments.error.team-not-entered-season", encode_entities($self->full_name)));
+    push(@{$response->{error}}, $lang->maketext("tables.adjustments.error.team-not-entered-season", encode_entities($self->full_name)));
   }
 }
 

--- a/lib/TopTable/Schema/Result/User.pm
+++ b/lib/TopTable/Schema/Result/User.pm
@@ -905,8 +905,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -917,7 +917,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("user.delete.error.cannot-delete", $name));
+    push(@{$response->{error}}, $lang->maketext("user.delete.error.cannot-delete", $name));
     return $response;
   }
   
@@ -929,7 +929,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;
@@ -952,8 +952,8 @@ sub approve {
   my $lang = $schema->lang;
   my $approver = $params->{approver};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -977,11 +977,11 @@ sub approve {
       $response->{completed} = 1;
       push(@{$response->{success}}, $lang->maketext("users.approve.user-approved", encode_entities($self->username)));
     } else {
-      push(@{$response->{errors}}, $lang->maketext("admin.update.error.database"));
+      push(@{$response->{error}}, $lang->maketext("admin.update.error.database"));
     }
   } else {
     # No user passed in
-    push(@{$response->{errors}}, $lang->maketext("admin.performing-user-invalid"));
+    push(@{$response->{error}}, $lang->maketext("admin.performing-user-invalid"));
   }
   
   return $response;
@@ -1004,8 +1004,8 @@ sub reject {
   my $lang = $schema->lang;
   my $approver = $params->{approver};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1020,7 +1020,7 @@ sub reject {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("users.approve.user-rejected", encode_entities($self->username)));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database"));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database"));
   }
   
   return $response;
@@ -1079,8 +1079,8 @@ sub activate {
   my $lang = $schema->lang;
   my $activation_key = $params->{activation_key};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1116,11 +1116,11 @@ sub activate {
         
         $response->{completed} = 1;
       } else {
-        push(@{$response->{errors}}, $lang->maketext("user.activation.error.failed"));
+        push(@{$response->{error}}, $lang->maketext("user.activation.error.failed"));
       }
     } else {
       # Activation key not recognised, error
-      push(@{$response->{errors}}, $lang->maketext("user.activation.error.key-incorrect"));
+      push(@{$response->{error}}, $lang->maketext("user.activation.error.key-incorrect"));
     }
   }
   
@@ -1144,8 +1144,8 @@ sub set_password_reset_key {
   my $lang = $schema->lang;
   my $person = $params->{person};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1165,7 +1165,7 @@ sub set_password_reset_key {
     $response->{completed} = 1;
     $response->{password_reset_key} = $reset_key;
   } else {
-    push(@{$response->{errors}}, $lang->maketext("user.forgot-password.error.failed-to-set-key"));
+    push(@{$response->{error}}, $lang->maketext("user.forgot-password.error.failed-to-set-key"));
   }
   
   return $response;
@@ -1189,8 +1189,8 @@ sub regenerate_activation_key {
   my $lang = $schema->lang;
   my $person = $params->{person};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1201,14 +1201,14 @@ sub regenerate_activation_key {
     # Already activated - this is an error, but which error gets shown depends on the approval status
     if ( $self->approved ) {
       # Already activated, but not approved
-      push(@{$response->{errors}}, $lang->maketext("user.activation.error-already-activated-needs-approval"));
+      push(@{$response->{error}}, $lang->maketext("user.activation.error-already-activated-needs-approval"));
     } else {
       # Already activated and can login
-      push(@{$response->{errors}}, $lang->maketext("user.activation.error-already-activated"));
+      push(@{$response->{error}}, $lang->maketext("user.activation.error-already-activated"));
     }
   }
   
-  if ( @{$response->{errors}} == 0 ) {
+  if ( @{$response->{error}} == 0 ) {
     my $activation_key = random_bytes_hex(32);
     my $activation_expires = DateTime->now(time_zone  => "UTC")->add(hours => $activation_expiry_limit);
     
@@ -1240,8 +1240,8 @@ sub reset_password {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -1262,42 +1262,42 @@ sub reset_password {
       if ( $self->check_key({type => "password_reset_key", val => $password_reset_key}) ) {
       } else {
         # Key incorrect
-        push(@{$response->{errors}}, $lang->maketext("user.reset-password.error.key-expired-invalid"));
+        push(@{$response->{error}}, $lang->maketext("user.reset-password.error.key-expired-invalid"));
       }
     } else {
       # Password reset key expired
-      push(@{$response->{errors}}, $lang->maketext("user.reset-password.error.key-expired-invalid"));
+      push(@{$response->{error}}, $lang->maketext("user.reset-password.error.key-expired-invalid"));
     }
   } else {
     # No password reset key, just say it's invalid (don't say this user doesn't have one, that's too much information)
-    push(@{$response->{errors}}, $lang->maketext("user.reset-password.error.key-expired-invalid"));
+    push(@{$response->{error}}, $lang->maketext("user.reset-password.error.key-expired-invalid"));
   }
   
   # No password checking if the reset key is invalid in some way, just return
-  return $response if scalar(@{$response->{errors}});
+  return $response if scalar(@{$response->{error}});
   
   if ( defined($password) ) {
     # Check the passwords match
     if ( $password ne $confirm_password ) {
       # Non-matching passwords
-      push(@{$response->{errors}}, $lang->maketext("user.form.error.password-confirm-mismatch"));
+      push(@{$response->{error}}, $lang->maketext("user.form.error.password-confirm-mismatch"));
     } else {
       # Check password strength
       if ( length($password) < 8 ) {
         # Password too short
-        push(@{$response->{errors}}, $lang->maketext("user.form.error.password-too-short", 8));
+        push(@{$response->{error}}, $lang->maketext("user.form.error.password-too-short", 8));
       } else {
         # Check password complexity
-        push(@{$response->{errors}}, $lang->maketext("user.form.error.password-complexity")) unless $password =~ /[A-Z]/ and $password =~ /[a-z]/ and $password =~ /\d/;
+        push(@{$response->{error}}, $lang->maketext("user.form.error.password-complexity")) unless $password =~ /[A-Z]/ and $password =~ /[a-z]/ and $password =~ /\d/;
       }
     }
   } else {
     # Password is blank
-    push(@{$response->{errors}}, $lang->maketext("user.form.error.password-blank"));
+    push(@{$response->{error}}, $lang->maketext("user.form.error.password-blank"));
   }
   
   # Update if there are no errors.  Ensure the password reset key is removed.
-  if ( scalar( @{$response->{errors}} ) == 0 ) {
+  if ( scalar( @{$response->{error}} ) == 0 ) {
     my $ok = $self->update({
       password => $password,
       password_reset_key => undef,
@@ -1307,7 +1307,7 @@ sub reset_password {
     if ( $ok ) {
       $response->{completed} = 1;
     } else {
-      push(@{$response->{errors}}, $lang->maketext("user.reset-password.error.failed-to-reset"));
+      push(@{$response->{error}}, $lang->maketext("user.reset-password.error.failed-to-reset"));
     }
   }
   

--- a/lib/TopTable/Schema/Result/Venue.pm
+++ b/lib/TopTable/Schema/Result/Venue.pm
@@ -407,8 +407,8 @@ sub check_and_delete {
   $schema->_set_maketext(TopTable::Maketext->get_handle($locale)) unless defined($schema->lang);
   my $lang = $schema->lang;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     completed => 0,
@@ -419,7 +419,7 @@ sub check_and_delete {
   
   # Check we can delete
   unless ( $self->can_delete ) {
-    push(@{$response->{errors}}, $lang->maketext("venues.delete.error.cannot-delete", $name));
+    push(@{$response->{error}}, $lang->maketext("venues.delete.error.cannot-delete", $name));
     return $response;
   }
   
@@ -431,7 +431,7 @@ sub check_and_delete {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $name, $lang->maketext("admin.message.deleted")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("admin.delete.error.database", $name));
+    push(@{$response->{error}}, $lang->maketext("admin.delete.error.database", $name));
   }
   
   return $response;

--- a/lib/TopTable/Schema/ResultSet/AverageFilter.pm
+++ b/lib/TopTable/Schema/ResultSet/AverageFilter.pm
@@ -114,8 +114,8 @@ sub create_or_edit {
   my $criteria = delete $params->{criteria} || undef;
   my $user = delete $params->{user} || undef;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {
@@ -133,7 +133,7 @@ sub create_or_edit {
   } elsif ( $action eq "edit" ) {
     unless ( defined( $filter ) and ref( $filter ) eq "TopTable::Model::DB::AverageFilter" ) {
       # Editing a meeting type that doesn't exist.
-      push(@{$response->{errors}}, $lang->maketext("average-filter.form.error.filter-invalid"));
+      push(@{$response->{error}}, $lang->maketext("average-filter.form.error.filter-invalid"));
       
       # Another fatal error
       return $response;
@@ -145,7 +145,7 @@ sub create_or_edit {
     # Creating - make sure we have a valid user (if defined).  We should never set this error, as the currently
     # logged in user should get passed in. 
     if ( defined($user) and ref($user) ne "Catalyst::Authentication::Store::DBIx::Class::User" ) {
-      push(@{$response->{errors}}, $lang->maketext("average-filter.form.error.user-invalid"));
+      push(@{$response->{error}}, $lang->maketext("average-filter.form.error.user-invalid"));
       return $response;
     }
   }
@@ -176,10 +176,10 @@ sub create_or_edit {
     
     # The message is slightly different for public and user filters
     my $message_id = ( defined($user) ) ? "average-filter.form.error.name-exists-user" : "average-filter.form.error.name-exists-public";
-    push(@{$response->{errors}}, $lang->maketext($message_id)) if defined($filter_name_check);
+    push(@{$response->{error}}, $lang->maketext($message_id)) if defined($filter_name_check);
   } else {
     # Name omitted.
-    push(@{$response->{errors}}, $lang->maketext("average-filter.form.error.name-blank"));
+    push(@{$response->{error}}, $lang->maketext("average-filter.form.error.name-blank"));
   }
   
   # Check player types - first set to an arrayref if it's not already, so we know we can loop
@@ -204,31 +204,31 @@ sub create_or_edit {
     $response->{fields}{show_inactive} = $show_inactive;
     
     # No valid types selected
-    push(@{$response->{errors}}, $lang->maketext("average-filter.form.error.no-player-types")) unless $show_active or $show_loan or $show_inactive;
+    push(@{$response->{error}}, $lang->maketext("average-filter.form.error.no-player-types")) unless $show_active or $show_loan or $show_inactive;
   } else {
     # No recipients, error
-    push(@{$response->{errors}}, $lang->maketext("average-filter.form.error.no-player-types"));
+    push(@{$response->{error}}, $lang->maketext("average-filter.form.error.no-player-types"));
   }
   
   # Check the criteria fields as long as at least one is filled out
   if ( defined($criteria_field) or defined($operator) or defined($criteria) or defined($criteria_type) ) {
     unless ( $criteria_field eq "played" or $criteria_field eq "won" or $criteria_field eq "lost" ) {
-      push(@{$response->{errors}}, $lang->maketext("average-filter.form.error.criteria-field-invalid"));
+      push(@{$response->{error}}, $lang->maketext("average-filter.form.error.criteria-field-invalid"));
       $criteria_field = "";
     }
     
     unless ( $operator eq ">" or $operator eq ">=" or $operator eq "=" or $operator eq "<=" or $operator eq "<" ) {
-      push(@{$response->{errors}}, $lang->maketext("average-filter.form.error.operator-invalid"));
+      push(@{$response->{error}}, $lang->maketext("average-filter.form.error.operator-invalid"));
       $operator = "";    
     }
     
     unless ( !defined($criteria) or $criteria =~ /^\d+$/ ) {
-      push(@{$response->{errors}}, $lang->maketext("average-filter.form.error.criteria-invalid"));
+      push(@{$response->{error}}, $lang->maketext("average-filter.form.error.criteria-invalid"));
       $criteria = "";
     }
     
     unless ( $criteria_type eq "matches" or $criteria_type eq "matches-pc" or $criteria_type eq "games" ) {
-      push(@{$response->{errors}}, $lang->maketext("average-filter.form.error.criteria-type-invalid"));
+      push(@{$response->{error}}, $lang->maketext("average-filter.form.error.criteria-type-invalid"));
       $criteria_type = "";
     }
   }
@@ -238,7 +238,7 @@ sub create_or_edit {
   $response->{fields}{criteria} = $criteria;
   $response->{fields}{criteria_type} = $criteria_type;
   
-  if ( scalar(@{$response->{errors}} ) == 0 ) {
+  if ( scalar(@{$response->{error}} ) == 0 ) {
     # Generate a new URL key
     my $url_key;
     if ( $action eq "edit" ) {

--- a/lib/TopTable/Schema/ResultSet/ContactReason.pm
+++ b/lib/TopTable/Schema/ResultSet/ContactReason.pm
@@ -80,8 +80,8 @@ sub create_or_edit {
   my $recipients = $params->{recipients};
   my $recipient_ids = $params->{recipient_ids};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {
@@ -92,14 +92,14 @@ sub create_or_edit {
   
   if ( $action ne "create" and $action ne "edit" ) {
     # Invalid action passed
-    push(@{ $response->{errors} }, $lang->maketext("admin.form.invalid-action", $action));
+    push(@{ $response->{error} }, $lang->maketext("admin.form.invalid-action", $action));
     
     # This error is fatal, so we return straight away
     return $response;
   } elsif ( $action eq "edit" ) {
     unless ( defined( $reason ) and ref( $reason ) eq "TopTable::Model::DB::MeetingType" ) {
       # Editing a meeting type that doesn't exist.
-      push(@{ $response->{errors} }, $lang->maketext("meeting-types.form.error.meeting-type-invalid"));
+      push(@{ $response->{error} }, $lang->maketext("meeting-types.form.error.meeting-type-invalid"));
       
       # Another fatal error
       return $response;
@@ -110,10 +110,10 @@ sub create_or_edit {
   # Check the names were entered and don't exist already.
   if ( defined($name) ) {
     # Full name entered, check it.
-    push(@{$response->{errors}}, $lang->maketext("contact-reasons.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $reason}));
+    push(@{$response->{error}}, $lang->maketext("contact-reasons.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $reason}));
   } else {
     # Full name omitted.
-    push(@{$response->{errors}}, $lang->maketext("ontact-reasons.form.error.name-blank"));
+    push(@{$response->{error}}, $lang->maketext("ontact-reasons.form.error.name-blank"));
   }
   
   # Check recipients - first set to an arrayref if it's not already, so we know we can loop
@@ -151,7 +151,7 @@ sub create_or_edit {
             $recipient_ids{$recipient->id} = 1;
           } else {
             # No email address, error
-            push(@{ $response->{errors} }, $lang->maketext("contact-reasons.form.error.no-email-for-person", $recipient->display_name));
+            push(@{ $response->{error} }, $lang->maketext("contact-reasons.form.error.no-email-for-person", $recipient->display_name));
           }
           
           # Push on to the fields
@@ -168,14 +168,14 @@ sub create_or_edit {
     
     if ( $invalid_recipients ) {
       my $message_id = ( $invalid_recipients == 1 ) ? "contact-reasons.form.error.invalid-recipients-single" : "contact-reasons.form.error.invalid-recipients-multiple";
-      push(@{ $response->{errors} }, $lang->maketext($message_id, $invalid_recipients));
+      push(@{ $response->{error} }, $lang->maketext($message_id, $invalid_recipients));
     }
   } else {
     # No recipients, error
-    push(@{ $response->{errors} }, $lang->maketext("contact-reasons.form.error.no-recipients"));
+    push(@{ $response->{error} }, $lang->maketext("contact-reasons.form.error.no-recipients"));
   }
   
-  if ( scalar( @{ $response->{errors} } ) == 0 ) {
+  if ( scalar( @{ $response->{error} } ) == 0 ) {
     # Generate a new URL key
     my $url_key;
     if ( $action eq "edit" ) {

--- a/lib/TopTable/Schema/ResultSet/Event.pm
+++ b/lib/TopTable/Schema/ResultSet/Event.pm
@@ -169,8 +169,8 @@ sub create_or_edit {
   
   my $season = $schema->resultset("Season")->get_current;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {
@@ -182,14 +182,14 @@ sub create_or_edit {
   
   if ( $action ne "create" and $action ne "edit" ) {
     # Invalid action passed
-    push(@{$response->{errors}}, $lang->maketext("admin.form.invalid-action", $action));
+    push(@{$response->{error}}, $lang->maketext("admin.form.invalid-action", $action));
     
     # This error is fatal, so we return straight away
     return $response;
   } elsif ( $action eq "edit" ) {
     # Check the event passed is valid
     unless ( defined($event) and $event->isa("TopTable::Schema::Result::Event") ) {
-      push(@{$response->{errors}}, $lang->maketext("event.form.error.event-invalid"));
+      push(@{$response->{error}}, $lang->maketext("event.form.error.event-invalid"));
       
       # Another fatal error
       return $response;
@@ -198,7 +198,7 @@ sub create_or_edit {
   
   unless ( defined($season) ) {
     my $action_desc = $action eq "create" ? $lang->maketext("admin.message.created") : $lang->maketext("admin.message.edited");
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.no-current-season", $action_desc));
+    push(@{$response->{error}}, $lang->maketext("events.form.error.no-current-season", $action_desc));
   }
   
   # Required fields - certain keys get deleted depending on the values of other fields
@@ -210,10 +210,10 @@ sub create_or_edit {
   # Check the names were entered and don't exist already.
   if ( defined($name) ) {
     # Name entered, check it.
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $event}));
+    push(@{$response->{error}}, $lang->maketext("events.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $event}));
   } else {
     # Name omitted.
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.name-blank"));
+    push(@{$response->{error}}, $lang->maketext("events.form.error.name-blank"));
   }
   
   if ( $action eq "create" or $event->can_edit_event_type ) {
@@ -247,11 +247,11 @@ sub create_or_edit {
               }
             } else {
               # Invalid tournament type
-              push(@{$response->{errors}}, $lang->maketext("events.form.error.tournament-type-invalid"));
+              push(@{$response->{error}}, $lang->maketext("events.form.error.tournament-type-invalid"));
             }
           } else {
             # Tournament type not given
-            push(@{$response->{errors}}, $lang->maketext("events.form.error.tournament-type-blank"));
+            push(@{$response->{error}}, $lang->maketext("events.form.error.tournament-type-blank"));
           }
         } else {
           # Not a tournament, so we don't need a tournament type
@@ -259,11 +259,11 @@ sub create_or_edit {
         }
       } else {
         # Event type invalid
-        push(@{$response->{errors}}, $lang->maketext("events.form.error.event-type-invalid"));
+        push(@{$response->{error}}, $lang->maketext("events.form.error.event-type-invalid"));
       }
     } else {
       # Event type blank
-      push(@{$response->{errors}}, $lang->maketext("events.form.error.event-type-blank"));
+      push(@{$response->{error}}, $lang->maketext("events.form.error.event-type-blank"));
     }
   }
   
@@ -276,9 +276,9 @@ sub create_or_edit {
       # Templates have to be team
       if ( defined($default_team_match_template) ) {
         $default_team_match_template = $schema->resultset("TemplateMatchTeam")->find_id_or_url_key($default_team_match_template) unless $default_team_match_template->isa("TopTable::Schema::Result::TemplateMatchTeam");
-        push(@{$response->{errors}}, $lang->maketext("events.form.error.def-match-template-invalid")) unless $default_team_match_template->isa("TopTable::Schema::Result::TemplateMatchTeam");
+        push(@{$response->{error}}, $lang->maketext("events.form.error.def-match-template-invalid")) unless $default_team_match_template->isa("TopTable::Schema::Result::TemplateMatchTeam");
       } else {
-        push(@{$response->{errors}}, $lang->maketext("events.form.error.def-match-template-blank"));
+        push(@{$response->{error}}, $lang->maketext("events.form.error.def-match-template-blank"));
       }
       
       # We don't want an individual match template for team entry events
@@ -297,10 +297,10 @@ sub create_or_edit {
         $allow_loan_players_multiple_teams = $allow_loan_players_multiple_teams ? 1 : 0;
         
         # Check the limits are numeric and not negative
-        push(@{$response->{errors}}, $lang->maketext("events.form.error.loan-playerss-limit-per-player-invalid")) unless $loan_players_limit_per_player =~ m/^\d{1,2}$/;
-        push(@{$response->{errors}}, $lang->maketext("events.form.error.loan-players-limit-per-player-per-team-invalid")) unless $loan_players_limit_per_player_per_team =~ m/^\d{1,2}$/;
-        push(@{$response->{errors}}, $lang->maketext("events.form.error.loan-players-limit-per-player-per-opposition-invalid")) unless $loan_players_limit_per_player_per_opposition =~ m/^\d{1,2}$/;
-        push(@{$response->{errors}}, $lang->maketext("events.form.error.loan-players-limit-per-team-invalid")) unless $loan_players_limit_per_team =~ m/^\d{1,2}$/;
+        push(@{$response->{error}}, $lang->maketext("events.form.error.loan-playerss-limit-per-player-invalid")) unless $loan_players_limit_per_player =~ m/^\d{1,2}$/;
+        push(@{$response->{error}}, $lang->maketext("events.form.error.loan-players-limit-per-player-per-team-invalid")) unless $loan_players_limit_per_player_per_team =~ m/^\d{1,2}$/;
+        push(@{$response->{error}}, $lang->maketext("events.form.error.loan-players-limit-per-player-per-opposition-invalid")) unless $loan_players_limit_per_player_per_opposition =~ m/^\d{1,2}$/;
+        push(@{$response->{error}}, $lang->maketext("events.form.error.loan-players-limit-per-team-invalid")) unless $loan_players_limit_per_team =~ m/^\d{1,2}$/;
       } else {
         # No loan players, zero all other options
         $allow_loan_players_above = 0;
@@ -334,9 +334,9 @@ sub create_or_edit {
       # Templates have to be individual for any tournament entry type other than team (singles or doubles)
       if ( defined($default_individual_match_template) ) {
         $default_individual_match_template = $schema->resultset("TemplateMatchIndividual")->find_id_or_url_key($default_individual_match_template) unless $default_individual_match_template->isa("TopTable::Schema::Result::TemplateMatchIndividual");
-        push(@{$response->{errors}}, $lang->maketext("events.form.error.def-match-template-invalid")) unless $default_individual_match_template->isa("TopTable::Schema::Result::TemplateMatchIndividual");
+        push(@{$response->{error}}, $lang->maketext("events.form.error.def-match-template-invalid")) unless $default_individual_match_template->isa("TopTable::Schema::Result::TemplateMatchIndividual");
       } else {
-        push(@{$response->{errors}}, $lang->maketext("events.form.error.def-match-template-blank"));
+        push(@{$response->{error}}, $lang->maketext("events.form.error.def-match-template-blank"));
       }
       
       # We don't want a team match template for singles or doubles entry events
@@ -353,14 +353,14 @@ sub create_or_edit {
     if ( !$venue->isa("TopTable::Schema::Result::Venue") ) {
       # Venue hasn't been passed in as an object, try and lookup as an ID / URL key
       $venue = $schema->resultset("Venue")->find_id_or_url_key($venue);
-      push(@{$response->{errors}}, $lang->maketext("events.form.error.venue-invalid")) unless defined($venue);
+      push(@{$response->{error}}, $lang->maketext("events.form.error.venue-invalid")) unless defined($venue);
     }
     
     # Now check the venue is active if we have one
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.venue-inactive", encode_entities($venue->name))) if defined($venue) and !$venue->active;
+    push(@{$response->{error}}, $lang->maketext("events.form.error.venue-inactive", encode_entities($venue->name))) if defined($venue) and !$venue->active;
   } else {
     # Venue is blank - only error if we've determined it's required
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.venue-blank")) if $venue_required;
+    push(@{$response->{error}}, $lang->maketext("events.form.error.venue-blank")) if $venue_required;
   }
   
   # Push the sanitised field back
@@ -371,7 +371,7 @@ sub create_or_edit {
     if ( !$organiser->isa("TopTable::Schema::Result::Person") ) {
       # Not passed in as an object, check if it's a valid ID / URL key
       $organiser = $schema->resultset("Person")->find_id_or_url_key($organiser);
-      push(@{$response->{errors}}, $lang->maketext("events.form.error.organiser-invalid")) unless defined($organiser);
+      push(@{$response->{error}}, $lang->maketext("events.form.error.organiser-invalid")) unless defined($organiser);
     }
   }
   
@@ -468,26 +468,26 @@ sub create_or_edit {
   $response->{fields}{round_date} = $round_date;
   
   # Push any start date error we found here
-  push(@{$response->{errors}}, $date_errors{start_date}) if $date_errors{start_date};
+  push(@{$response->{error}}, $date_errors{start_date}) if $date_errors{start_date};
   
   # Check the start time is valid if we need it
   if ( defined($start_hour) ) {
     # Passed in, check it's valid
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.start-hour-invalid")) unless $start_hour =~ m/^(?:0[0-9]|1[0-9]|2[0-3])$/;
+    push(@{$response->{error}}, $lang->maketext("events.form.error.start-hour-invalid")) unless $start_hour =~ m/^(?:0[0-9]|1[0-9]|2[0-3])$/;
   } else {
     # Blank, error if it's required
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.start-hour-blank")) if $start_time_required;
+    push(@{$response->{error}}, $lang->maketext("events.form.error.start-hour-blank")) if $start_time_required;
   }
   
   if ( defined($start_minute) ) {
     # Passed in, check it's valid
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.start-minute-invalid")) unless $start_minute =~ m/^(?:[0-5][0-9])$/;
+    push(@{$response->{error}}, $lang->maketext("events.form.error.start-minute-invalid")) unless $start_minute =~ m/^(?:[0-5][0-9])$/;
   } else {
     # Blank, error if it's required
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.start-minute-blank")) if $start_time_required;
+    push(@{$response->{error}}, $lang->maketext("events.form.error.start-minute-blank")) if $start_time_required;
   }
   
-  push(@{$response->{errors}}, $lang->maketext("events.form.error.start-time-partially-blank")) if (!$start_time_required and (defined($start_hour) and !defined($start_minute)) or (!defined($start_hour) and defined($start_minute)));
+  push(@{$response->{error}}, $lang->maketext("events.form.error.start-time-partially-blank")) if (!$start_time_required and (defined($start_hour) and !defined($start_minute)) or (!defined($start_hour) and defined($start_minute)));
   
   if ( $all_day ) {
     # All day events don't have a finish time
@@ -496,20 +496,20 @@ sub create_or_edit {
     undef($end_minute);
   } else {
     # Push any start date error we found here
-    push(@{$response->{errors}}, $date_errors{end_date}) if $date_errors{end_date};
+    push(@{$response->{error}}, $date_errors{end_date}) if $date_errors{end_date};
     
     # Check the finish time, if it's provided
     if ( defined($end_hour) ) {
       # Passed in, check it's valid
-      push(@{$response->{errors}}, $lang->maketext("events.form.error.finish-hour-invalid")) unless $end_hour =~ m/^(?:0[0-9]|1[0-9]|2[0-3])$/;
+      push(@{$response->{error}}, $lang->maketext("events.form.error.finish-hour-invalid")) unless $end_hour =~ m/^(?:0[0-9]|1[0-9]|2[0-3])$/;
     }
     
     if ( defined($end_minute) ) {
       # Passed in, check it's valid
-      push(@{$response->{errors}}, $lang->maketext("events.form.error.finish-minute-invalid")) unless $end_minute =~ m/^(?:[0-5][0-9])$/;
+      push(@{$response->{error}}, $lang->maketext("events.form.error.finish-minute-invalid")) unless $end_minute =~ m/^(?:[0-5][0-9])$/;
     }
     
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.end-time-partially-blank")) if (defined($end_hour) and !defined($end_minute)) or (!defined($end_hour) and defined($end_minute));
+    push(@{$response->{error}}, $lang->maketext("events.form.error.end-time-partially-blank")) if (defined($end_hour) and !defined($end_minute)) or (!defined($end_hour) and defined($end_minute));
   }
   
   # Add the start time to the date if it's provided
@@ -530,7 +530,7 @@ sub create_or_edit {
   if ( defined($start_date) and defined($end_date) ) {
     if ( DateTime->compare($start_date, $end_date) == 1 ) {
       # Start date is before end date
-      push(@{$response->{errors}}, $lang->maketext("events.form.error.start-date-must-be-before-end-date"));
+      push(@{$response->{error}}, $lang->maketext("events.form.error.start-date-must-be-before-end-date"));
     }
   }
   
@@ -547,10 +547,10 @@ sub create_or_edit {
       if ( defined($round_group_rank_template) ) {
         # Check we have a valid table rank template
         $round_group_rank_template = $schema->resultset("TemplateLeagueTableRanking")->find($round_group_rank_template) unless $round_group_rank_template->isa("TopTable::Schema::Result::TemplateLeagueTableRanking");
-        push(@{$response->{errors}}, $lang->maketext("events.tournaments.rounds.form.error.table-ranking-template-invalid")) unless defined($round_group_rank_template);
+        push(@{$response->{error}}, $lang->maketext("events.tournaments.rounds.form.error.table-ranking-template-invalid")) unless defined($round_group_rank_template);
       } else {
         # Error, we need a table rank template in a group round
-        push(@{$response->{errors}}, $lang->maketext("events.tournaments.rounds.form.error.table-ranking-template-blank"));
+        push(@{$response->{error}}, $lang->maketext("events.tournaments.rounds.form.error.table-ranking-template-blank"));
       }
     } else {
       # Not a group round, ensure the ranking template is undef
@@ -565,7 +565,7 @@ sub create_or_edit {
       if ( defined($round_team_match_template) ) {
         # Lookup the first round team match template if it's provided (and not already a template object)
         $round_team_match_template = $schema->resultset("TemplateMatchTeam")->find($round_team_match_template) unless $round_team_match_template->isa("TopTable::Schema::Result::TemplateMatchTeam");
-        push(@{$response->{errors}}, $lang->maketext("events.tournaments.rounds.form.error.match-template-invalid")) unless defined($round_team_match_template);
+        push(@{$response->{error}}, $lang->maketext("events.tournaments.rounds.form.error.match-template-invalid")) unless defined($round_team_match_template);
         
         # Ensure the individual match template is undef
         undef($round_individual_match_template);
@@ -575,7 +575,7 @@ sub create_or_edit {
       if ( defined($round_individual_match_template) ) {
         # Lookup the first round team match template if it's provided (and not already a template object)
         $round_individual_match_template = $schema->resultset("TemplateMatchIndividual")->find($round_individual_match_template) unless $round_individual_match_template->isa("TopTable::Schema::Result::TemplateMatchIndividual");
-        push(@{$response->{errors}}, $lang->maketext("events.tournaments.rounds.form.error.match-template-invalid")) unless defined($round_individual_match_template);
+        push(@{$response->{error}}, $lang->maketext("events.tournaments.rounds.form.error.match-template-invalid")) unless defined($round_individual_match_template);
         
         # Ensure the individual match template is undef
         undef($round_team_match_template);
@@ -583,7 +583,7 @@ sub create_or_edit {
     }
     
     # The date is already checked in the dates loop above, put hte error here if we have one
-    push(@{$response->{errors}}, $date_errors{round_date}) if $date_errors{round_date};
+    push(@{$response->{error}}, $date_errors{round_date}) if $date_errors{round_date};
     
     # Check the round venue if supplied
     if ( defined($round_venue) ) {
@@ -591,17 +591,17 @@ sub create_or_edit {
       
       if ( defined($round_venue) ) {
         # Venue is valid, but need to check it's active
-        push(@{$response->{errors}}, $lang->maketext("events.tournaments.rounds.form.error.venue-inactive", encode_entities($venue->name))) unless $round_venue->active;
+        push(@{$response->{error}}, $lang->maketext("events.tournaments.rounds.form.error.venue-inactive", encode_entities($venue->name))) unless $round_venue->active;
       } else {
         # Invalid venue
-        push(@{$response->{errors}}, $lang->maketext("events.tournaments.rounds.form.error.venue-invalid"));
+        push(@{$response->{error}}, $lang->maketext("events.tournaments.rounds.form.error.venue-invalid"));
       }
     }
     
     $response->{fields}{round_venue} = $round_venue;
   }
   
-  if ( scalar(@{$response->{errors}}) == 0 ) {
+  if ( scalar(@{$response->{error}}) == 0 ) {
     # Success, we need to create / edit the event
     # Build the key from the name
     my $url_key;
@@ -669,8 +669,8 @@ sub create_or_edit {
           });
           
           # Push any responses we get back to the calling routine
-          push(@{$response->{errors}}, @{$round_response->{errors}});
-          push(@{$response->{warnings}}, @{$round_response->{warnings}});
+          push(@{$response->{error}}, @{$round_response->{error}});
+          push(@{$response->{warning}}, @{$round_response->{warning}});
           push(@{$response->{info}}, @{$round_response->{info}});
           push(@{$response->{success}}, @{$round_response->{success}});
           $response->{round_completed} = $round_response->{completed};

--- a/lib/TopTable/Schema/ResultSet/FixturesGrid.pm
+++ b/lib/TopTable/Schema/ResultSet/FixturesGrid.pm
@@ -189,8 +189,8 @@ sub create_or_edit {
   my $maximum_teams = $params->{maximum_teams};
   my $fixtures_repeated = $params->{fixtures_repeated};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {
@@ -203,13 +203,13 @@ sub create_or_edit {
   
   if ($action ne "create" and $action ne "edit") {
     # Invalid action passed
-    push(@{$response->{errors}}, $lang->maketext("admin.form.invalid-action", $action));
+    push(@{$response->{error}}, $lang->maketext("admin.form.invalid-action", $action));
     
     return $response;
   } elsif ($action eq "edit") {
     unless ( defined($grid) and ref($grid) eq "TopTable::Model::DB::FixturesGrid" ) {
       # Editing a fixtures grid that doesn't exist.
-      push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.grid-invalid"));
+      push(@{$response->{error}}, $lang->maketext("fixtures-grids.form.error.grid-invalid"));
       return $response;
     }
   }
@@ -221,22 +221,22 @@ sub create_or_edit {
   # Error checking
   # Check the names were entered and don't exist already.
   if ( defined($name) ) {
-    push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.grid-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $grid}));
+    push(@{$response->{error}}, $lang->maketext("fixtures-grids.form.error.grid-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $grid}));
   } else {
     # Name omitted.
-    push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.name-blank"));
+    push(@{$response->{error}}, $lang->maketext("fixtures-grids.form.error.name-blank"));
   }
   
   if ( $setup_rounds ) {
     # Check the maximum teams is a valid numeric value (2-98).
-    push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.maximum-teams-invalid")) if !$maximum_teams or $maximum_teams !~ m/^\d{1,2}$/ or $maximum_teams < 2 or $maximum_teams > 98 or $maximum_teams % 2 == 1;
+    push(@{$response->{error}}, $lang->maketext("fixtures-grids.form.error.maximum-teams-invalid")) if !$maximum_teams or $maximum_teams !~ m/^\d{1,2}$/ or $maximum_teams < 2 or $maximum_teams > 98 or $maximum_teams % 2 == 1;
     
     # Check the number of weeks is valid; this needs to be a valid numeric figure and
     # less than 52, as a season will definitely not last a year.
-    push(@{$response->{errors}}, $lang->maketext("fixtures-grids.form.error.repeat-fixtures-invalid")) if !$fixtures_repeated or $fixtures_repeated !~ m/^\d$/ or $fixtures_repeated < 1;
+    push(@{$response->{error}}, $lang->maketext("fixtures-grids.form.error.repeat-fixtures-invalid")) if !$fixtures_repeated or $fixtures_repeated !~ m/^\d$/ or $fixtures_repeated < 1;
   }
   
-  if ( scalar( @{$response->{errors}} ) == 0 ) {
+  if ( scalar( @{$response->{error}} ) == 0 ) {
     # Generate a URL key
     my $url_key;
     if ( $action eq "edit" ) {

--- a/lib/TopTable/Schema/ResultSet/Meeting.pm
+++ b/lib/TopTable/Schema/ResultSet/Meeting.pm
@@ -170,8 +170,8 @@ sub create_or_edit {
   
   my $is_event = 0;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {},
@@ -249,7 +249,7 @@ sub create_or_edit {
   
   if ( $action ne "create" and $action ne "edit" ) {
     # Invalid action passed
-    push(@{$response->{errors}}, $lang->maketext("admin.form.invalid-action", $action));
+    push(@{$response->{error}}, $lang->maketext("admin.form.invalid-action", $action));
     
     # This error is fatal, so we return straight away
     return $response;
@@ -260,7 +260,7 @@ sub create_or_edit {
       $is_event = 1 if defined($meeting->event);
     } else {
       # Meeting is invalid
-      push(@{$response->{errors}}, {id => "meetings.form.error.meeting-invalid"});
+      push(@{$response->{error}}, {id => "meetings.form.error.meeting-invalid"});
     }
   }
   
@@ -280,7 +280,7 @@ sub create_or_edit {
         if  ( defined($type) ) {
           $response->{fields}{type} = $type;
         } else {
-          push(@{$response->{errors}}, $lang->maketext("meetings.form.error.meeting-type-invalid"));
+          push(@{$response->{error}}, $lang->maketext("meetings.form.error.meeting-type-invalid"));
         }
         
         # Check the type / date combination isn't a duplicate (only if we haven't already errored on date validation above)
@@ -302,11 +302,11 @@ sub create_or_edit {
           }
         }
         
-        push(@{$response->{errors}}, $lang->maketext("meetings.form.error.meeting-type-and-date-exists", $type->name)) if defined($meeting_check);
+        push(@{$response->{error}}, $lang->maketext("meetings.form.error.meeting-type-and-date-exists", $type->name)) if defined($meeting_check);
       }
     } else {
       # Blank type
-      push(@{$response->{errors}}, $lang->maketext("meetings.form.error.meeting-type-blank"));
+      push(@{$response->{error}}, $lang->maketext("meetings.form.error.meeting-type-blank"));
     }
   }
   
@@ -317,14 +317,14 @@ sub create_or_edit {
     if ( defined($venue) ) {
       # Venue found, push back into the fields, error if inactive
       $response->{fields}{venue} = $venue;
-      push(@{$response->{errors}}, $lang->maketext("meetings.form.error.venue-inactive", encode_entities($venue->name))) unless $venue->active;
+      push(@{$response->{error}}, $lang->maketext("meetings.form.error.venue-inactive", encode_entities($venue->name))) unless $venue->active;
     } else {
       # Venue error
-      push(@{$response->{errors}}, $lang->maketext("meetings.form.error.venue-invalid")); # Venue will now be undef if we haven't managed to find it with the ID and it wasn't a Venue in the first place
+      push(@{$response->{error}}, $lang->maketext("meetings.form.error.venue-invalid")); # Venue will now be undef if we haven't managed to find it with the ID and it wasn't a Venue in the first place
     }
   } else {
     # Blank venue
-    push(@{$response->{errors}}, $lang->maketext("meetings.form.error.venue-blank"));
+    push(@{$response->{error}}, $lang->maketext("meetings.form.error.venue-blank"));
   }
   
   # Check the organiser (not required, so if it's undefined or blank that's fine)
@@ -336,12 +336,12 @@ sub create_or_edit {
       $response->{fields}{organiser} = $organiser;
     } else {
       # Organiser invalid
-      push(@{$response->{errors}}, {id => "meetings.form.error.organiser-invalid"}) unless defined($venue); # Organiser will now be undef if we haven't managed to find it with the ID and it wasn't a Person in the first place
+      push(@{$response->{error}}, {id => "meetings.form.error.organiser-invalid"}) unless defined($venue); # Organiser will now be undef if we haven't managed to find it with the ID and it wasn't a Person in the first place
     }
   }
   
   # Push any start date error we found here
-  push(@{$response->{errors}}, $date_errors{start_date}) if $date_errors{start_date};
+  push(@{$response->{error}}, $date_errors{start_date}) if $date_errors{start_date};
   
   # Check the start time is valid
   if ( defined($start_hour) ) {
@@ -351,11 +351,11 @@ sub create_or_edit {
       $response->{fields}{start_hour} = $start_hour;
     } else {
       # Invalid start hour
-      push(@{$response->{errors}}, $lang->maketext("meetings.form.error.start-hour-invalid"));
+      push(@{$response->{error}}, $lang->maketext("meetings.form.error.start-hour-invalid"));
     }
   } else {
    # Blank start hour
-   push(@{$response->{errors}}, $lang->maketext("meetings.form.error.start-hour-blank"));
+   push(@{$response->{error}}, $lang->maketext("meetings.form.error.start-hour-blank"));
   }
   
   if ( defined($start_minute) ){
@@ -365,11 +365,11 @@ sub create_or_edit {
       $response->{fields}{start_minute} = $start_minute;
     } else {
       # Invalid start minute
-      push(@{$response->{errors}}, $lang->maketext("meetings.form.error.start-minute-invalid"));
+      push(@{$response->{error}}, $lang->maketext("meetings.form.error.start-minute-invalid"));
     }
   } else {
     # Blank start minute
-    push(@{$response->{errors}}, $lang->maketext("meetings.form.error.start-hour-blank"));
+    push(@{$response->{error}}, $lang->maketext("meetings.form.error.start-hour-blank"));
   }
   
   if ( $all_day ) {
@@ -379,20 +379,20 @@ sub create_or_edit {
     undef($end_minute);
   } else {
     # Push any start date error we found here
-    push(@{$response->{errors}}, $date_errors{start_date}) if $date_errors{start_date};
+    push(@{$response->{error}}, $date_errors{start_date}) if $date_errors{start_date};
     
     # Check the finish time, if it's provided
     if ( defined($end_hour) ) {
       # Passed in, check it's valid
-      push(@{$response->{errors}}, $lang->maketext("events.form.error.finish-hour-invalid")) unless $end_hour =~ m/^(?:0[0-9]|1[0-9]|2[0-3])$/;
+      push(@{$response->{error}}, $lang->maketext("events.form.error.finish-hour-invalid")) unless $end_hour =~ m/^(?:0[0-9]|1[0-9]|2[0-3])$/;
     }
     
     if ( defined($end_minute) ) {
       # Passed in, check it's valid
-      push(@{$response->{errors}}, $lang->maketext("events.form.error.finish-minute-invalid")) unless $end_minute =~ m/^(?:[0-5][0-9])$/;
+      push(@{$response->{error}}, $lang->maketext("events.form.error.finish-minute-invalid")) unless $end_minute =~ m/^(?:[0-5][0-9])$/;
     }
     
-    push(@{$response->{errors}}, $lang->maketext("events.form.error.end-time-partially-blank")) if (defined($end_hour) and !defined($end_minute)) or (!defined($end_hour) and defined($end_minute));
+    push(@{$response->{error}}, $lang->maketext("events.form.error.end-time-partially-blank")) if (defined($end_hour) and !defined($end_minute)) or (!defined($end_hour) and defined($end_minute));
   }
   
   # Add the start time to the date if it's provided
@@ -413,7 +413,7 @@ sub create_or_edit {
   if ( defined($start_date) and defined($end_date) ) {
     if ( DateTime->compare($start_date, $end_date) == 1 ) {
       # Start date is before end date
-      push(@{$response->{errors}}, $lang->maketext("events.form.error.start-date-must-be-before-end-date"));
+      push(@{$response->{error}}, $lang->maketext("events.form.error.start-date-must-be-before-end-date"));
     }
   }
   
@@ -435,7 +435,7 @@ sub create_or_edit {
   # Now check if we have anyone who appears on both lists
   if ( scalar(@{$people->{conflict}}) == 1 ) {
     # One person on both lists elicits a different message to multiple people
-    push(@{$response->{errors}}, $lang->maketext("meetings.form.error.attendee-on-both-lists", encode_entities($people->{conflict}[0]->display_name)));
+    push(@{$response->{error}}, $lang->maketext("meetings.form.error.attendee-on-both-lists", encode_entities($people->{conflict}[0]->display_name)));
   } elsif ( scalar(@{$people->{conflict}}) > 1 ) {
     # Multiple people on both lists, get their names and encode them for the error message
     # Save the number of conflicts, as we'll be popping the last one off here to build the message, so we need to get the total number early on
@@ -449,17 +449,17 @@ sub create_or_edit {
     
     my $conflict_people = sprintf("%s %s %s", join(", ", @people_names), $lang->maketext("msg.and"), $last);
     
-    push(@{$response->{errors}}, $lang->maketext("meetings.form.error.attendees-on-both-lists", $conflicts, $conflict_people));
+    push(@{$response->{error}}, $lang->maketext("meetings.form.error.attendees-on-both-lists", $conflicts, $conflict_people));
   }
   
   # Check for invalid attendees / apologies
-  push(@{$response->{errors}}, $lang->maketext("meetings.form.error.attendees-invalid", $people->{attendees}{invalid})) if $people->{attendees}{invalid};
-  push(@{$response->{errors}}, $lang->maketext("meetings.form.error.apologies-invalid", $people->{apologies}{invalid})) if $people->{apologies}{invalid};
+  push(@{$response->{error}}, $lang->maketext("meetings.form.error.attendees-invalid", $people->{attendees}{invalid})) if $people->{attendees}{invalid};
+  push(@{$response->{error}}, $lang->maketext("meetings.form.error.apologies-invalid", $people->{apologies}{invalid})) if $people->{apologies}{invalid};
   
   # Sanity check for the all day flag
   $all_day = $all_day ? 1 : 0;
   
-  if ( scalar(@{$response->{errors}}) == 0 ) {
+  if ( scalar(@{$response->{error}}) == 0 ) {
     # Success, we need to create / edit the meeting
     # We need to build the start time string - the start time is part of the date as well, so we just use DateTime to set the time.
     $start_date->set_hour($start_hour);

--- a/lib/TopTable/Schema/ResultSet/MeetingType.pm
+++ b/lib/TopTable/Schema/ResultSet/MeetingType.pm
@@ -64,8 +64,8 @@ sub create_or_edit {
   my $meeting_type = $params->{meeting_type};
   my $name = $params->{name} || undef;
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {name => $name},
@@ -74,7 +74,7 @@ sub create_or_edit {
   
   if ( $action ne "create" and $action ne "edit" ) {
     # Invalid action passed
-    push(@{$response->{errors}}, $lang->maketext("admin.form.invalid-action", $action));
+    push(@{$response->{error}}, $lang->maketext("admin.form.invalid-action", $action));
     
     # This error is fatal, so we return straight away
     return $response;
@@ -84,7 +84,7 @@ sub create_or_edit {
       $meeting_type = $class->find_id_or_url_key($meeting_type);
       
       # Definitely error if we're now undef
-      push(@{$response->{errors}}, $lang->maketext("meeting-types.form.error.meeting-type-invalid")) unless defined($meeting_type);
+      push(@{$response->{error}}, $lang->maketext("meeting-types.form.error.meeting-type-invalid")) unless defined($meeting_type);
       
       # Another fatal error
       return $response;
@@ -94,13 +94,13 @@ sub create_or_edit {
   # Error checking
   # Check the names were entered and don't exist already.
   if ( defined($name) ) {
-    push(@{$response->{errors}}, $lang->maketext("meeting-types.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $meeting_type}));
+    push(@{$response->{error}}, $lang->maketext("meeting-types.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $meeting_type}));
   } else {
     # Name omitted.
-    push(@{$response->{errors}}, $lang->maketext("meeting-types.form.error.name-blank"));
+    push(@{$response->{error}}, $lang->maketext("meeting-types.form.error.name-blank"));
   }
   
-  if ( scalar @{$response->{errors}} == 0 ) {
+  if ( scalar @{$response->{error}} == 0 ) {
     # Generate a new URL key
     my $url_key;
     if ( $action eq "edit" ) {

--- a/lib/TopTable/Schema/ResultSet/PageText.pm
+++ b/lib/TopTable/Schema/ResultSet/PageText.pm
@@ -38,8 +38,8 @@ sub edit {
   my $page_key = $params->{page_key};
   my $page_text = $params->{page_text};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {},
@@ -60,7 +60,7 @@ sub edit {
     $response->{completed} = 1;
     push(@{$response->{success}}, $lang->maketext("admin.forms.success", $lang->maketext("menu.text.$page_key"), $lang->maketext("admin.message.edited")));
   } else {
-    push(@{$response->{errors}}, $lang->maketext("page_text.form.error.page-key-missing"));
+    push(@{$response->{error}}, $lang->maketext("page_text.form.error.page-key-missing"));
   }
   
   return $response;

--- a/lib/TopTable/Schema/ResultSet/TemplateLeagueTableRanking.pm
+++ b/lib/TopTable/Schema/ResultSet/TemplateLeagueTableRanking.pm
@@ -124,8 +124,8 @@ sub create_or_edit {
   my $points_per_draw = $params->{points_per_draw};
   my $points_per_loss = $params->{points_per_loss};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {
@@ -140,7 +140,7 @@ sub create_or_edit {
   
   if ( $action ne "create" and $action ne "edit" ) {
     # Invalid action passed
-    push(@{$response->{errors}}, $lang->maketext("admin.form.invalid-action", $action));
+    push(@{$response->{error}}, $lang->maketext("admin.form.invalid-action", $action));
   } elsif ( $action eq "edit" ) {
     if ( defined($tt_template) ) {
       if ( !$tt_template->isa("TopTable::Schema::Result::TemplateLeagueTableRanking") ) {
@@ -148,29 +148,29 @@ sub create_or_edit {
         $tt_template = $class->find_id_or_url_key($tt_template);
         
         # Definitely error if we're now undef
-        push(@{$response->{errors}}, $lang->maketext("templates.league-table-ranking.form.error.template-invalid")) unless defined($tt_template);
+        push(@{$response->{error}}, $lang->maketext("templates.league-table-ranking.form.error.template-invalid")) unless defined($tt_template);
       }
       
       # Template is valid, check we can edit it.
       unless ( $tt_template->can_edit_or_delete ) {
-        push(@{$response->{errors}}, $lang->maketext("templates.edit.error.not-allowed", $tt_template->name));
+        push(@{$response->{error}}, $lang->maketext("templates.edit.error.not-allowed", $tt_template->name));
       }
     } else {
       # Editing a template that doesn't exist.
-      push(@{$response->{errors}}, $lang-maketext("templates.league-table-ranking.form.error.template-not-specified"));
+      push(@{$response->{error}}, $lang-maketext("templates.league-table-ranking.form.error.template-not-specified"));
     }
   }
   
   # Any errors at this point are fatal, so we return early
-  return $response if scalar @{$response->{errors}};
+  return $response if scalar @{$response->{error}};
   
   # Error checking
   # Check the names were entered and don't exist already.
   if ( defined($name) ) {
-    push(@{$response->{errors}}, $lang->maketext("templates.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $tt_template}));
+    push(@{$response->{error}}, $lang->maketext("templates.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $tt_template}));
   } else {
     # Name omitted.
-    push(@{$response->{errors}}, $lang->maketext("templates.form.error.name-blank"));
+    push(@{$response->{error}}, $lang->maketext("templates.form.error.name-blank"));
   }
   
   # Check the game type has been selected and is valid
@@ -180,26 +180,26 @@ sub create_or_edit {
     
     if ( defined($points_per_win) ) {
       # Value is submitted, ensure it's valid
-      push(@{$response->{errors}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-win-invalid")) if $points_per_win !~ m/\d{1,2}/ or $points_per_win < 1;
+      push(@{$response->{error}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-win-invalid")) if $points_per_win !~ m/\d{1,2}/ or $points_per_win < 1;
     } else {
       # Not submitted
-      push(@{$response->{errors}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-win-blank"));
+      push(@{$response->{error}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-win-blank"));
     }
     
     if ( defined($points_per_draw) ) {
       # Value is submitted, ensure it's valid
-      push(@{$response->{errors}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-draw-invalid")) if $points_per_draw !~ m/\d{1,2}/ or $points_per_draw < 1;
+      push(@{$response->{error}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-draw-invalid")) if $points_per_draw !~ m/\d{1,2}/ or $points_per_draw < 1;
     } else {
       # Not submitted
-      push(@{$response->{errors}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-draw-blank"));
+      push(@{$response->{error}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-draw-blank"));
     }
     
     if ( defined($points_per_loss) ) {
       # Value is submitted, ensure it's valid
-      push(@{$response->{errors}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-loss-invalid")) if $points_per_draw !~ m/\d{1,2}/ or $points_per_draw < 1;
+      push(@{$response->{error}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-loss-invalid")) if $points_per_draw !~ m/\d{1,2}/ or $points_per_draw < 1;
     } else {
       # Not submitted
-      push(@{$response->{errors}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-loss-blank"));
+      push(@{$response->{error}}, $lang->maketext("templates.league-table-ranking.form.error.points-per-loss-blank"));
     }
   } else {
     # Blank out the points per win / draw / loss, as we won't be using them
@@ -209,7 +209,7 @@ sub create_or_edit {
     undef($points_per_loss);
   }
   
-  if ( scalar @{$response->{errors}} == 0 ) {
+  if ( scalar @{$response->{error}} == 0 ) {
     # Build the key from the name
     my $url_key;
     if ( $action eq "edit" ) {

--- a/lib/TopTable/Schema/ResultSet/Venue.pm
+++ b/lib/TopTable/Schema/ResultSet/Venue.pm
@@ -160,8 +160,8 @@ sub create_or_edit {
   my $geolocation = $params->{geolocation} || undef;
   my $active = $params->{active};
   my $response = {
-    errors => [],
-    warnings => [],
+    error => [],
+    warning => [],
     info => [],
     success => [],
     fields => {
@@ -182,7 +182,7 @@ sub create_or_edit {
   
   if ( $action ne "create" and $action ne "edit" ) {
     # Invalid action passed
-    push(@{$response->{errors}}, $lang->maketext("admin.form.invalid-action", $action));
+    push(@{$response->{error}}, $lang->maketext("admin.form.invalid-action", $action));
     
     # This error is fatal, so we return straight away
     return $response;
@@ -193,13 +193,13 @@ sub create_or_edit {
         $venue = $class->find_id_or_url_key($venue);
         
         # Definitely error if we're now undef
-        push(@{$response->{errors}}, $lang->maketext("venues.form.error.venue-invalid")) unless defined($venue);
+        push(@{$response->{error}}, $lang->maketext("venues.form.error.venue-invalid")) unless defined($venue);
         
         # Another fatal error
         return $response;
       }
     } else {
-      push(@{$response->{errors}}, $lang->maketext("venues.form.error.venue-not-specified"));
+      push(@{$response->{error}}, $lang->maketext("venues.form.error.venue-not-specified"));
       return $response;
     }
     
@@ -211,10 +211,10 @@ sub create_or_edit {
   # Error checking
   # Check the names were entered and don't exist already.
   if ( defined($name) ) {
-    push(@{$response->{errors}}, $lang->maketext("venues.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $venue}));
+    push(@{$response->{error}}, $lang->maketext("venues.form.error.name-exists", encode_entities($name))) if defined($class->search_single_field({field => "name", value => $name, exclusion_obj => $venue}));
   } else {
     # Name omitted.
-    push(@{$response->{errors}}, $lang->maketext("venues.form.error.name-blank"));
+    push(@{$response->{error}}, $lang->maketext("venues.form.error.name-blank"));
   }
   
   my ( $map_lat, $map_lng );
@@ -231,16 +231,16 @@ sub create_or_edit {
       # Split it out again after
       ( $map_lat, $map_lng ) = split(",", $geolocation);
     } else {
-      push(@{$response->{errors}}, $lang->maketext("venues.form.error.map-coordinates-invalid"));
+      push(@{$response->{error}}, $lang->maketext("venues.form.error.map-coordinates-invalid"));
     }
   }
   
   # Phone / email - check they're valid (if entered)
-  push(@{$response->{errors}}, $lang->maketext("venues.form.error.telephone-invalid")) if ( defined($telephone) and $telephone !~ m/([0-9x ])/ );
+  push(@{$response->{error}}, $lang->maketext("venues.form.error.telephone-invalid")) if ( defined($telephone) and $telephone !~ m/([0-9x ])/ );
   
   if ( defined($email_address) ) {
     $email_address = Email::Valid->address($email_address);
-    push(@{$response->{errors}}, $lang->maketext("venues.form.error.email-invalid")) unless defined($email_address);
+    push(@{$response->{error}}, $lang->maketext("venues.form.error.email-invalid")) unless defined($email_address);
   }
   
   # Active - must be 1 or 0
@@ -252,7 +252,7 @@ sub create_or_edit {
     #$logger->("debug", sprintf("Active is not defined, setting to 0: %s", $active));
   }
   
-  if ( scalar @{$response->{errors}} == 0 ) {
+  if ( scalar @{$response->{error}} == 0 ) {
     # Success, we need to create the venue
     if ( $action eq "create" ) {
       $venue = $class->create({

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -2716,6 +2716,9 @@ msgstr "Not yet played"
 msgid "matches.versus.not-yet-received"
 msgstr "Not received"
 
+msgid "matches.versus.postponed"
+msgstr "Postponed, awaiting new date"
+
 msgid "matches.handicap.not-yet-set"
 msgstr "Handicap not set"
 
@@ -2745,6 +2748,9 @@ msgstr "Write a match report"
 
 msgid "matches.update.form.legend.match-details"
 msgstr "Match details"
+
+msgid "matches.field.postpone"
+msgstr "Mark postponed"
 
 msgid "matches.field.date"
 msgstr "Match date"
@@ -2866,6 +2872,21 @@ msgstr "The actual game number specified (%1) for scheduled game %2 is invalid; 
 
 msgid "matches.update-playing-order.error.game-specified-multiple"
 msgstr "The number %1 has been specified more than once (for game number %2 and %3)."
+
+msgid "matches.postpone-match.error.match-started"
+msgstr "The match cannot be postponed because there are scores entered for it already."
+
+msgid "matches.postpone-match.error.match-cancelled"
+msgstr "The match cannot be postponed because it has already been cancelled."
+
+msgid "matches.postpone-match.info.match-already-postponed"
+msgstr "The match has already been marked as postponed."
+
+msgid "matches.set-postponed.success"
+msgstr "The match was marked as postponed."
+
+msgid "matches.set-postponed.success-unset"
+msgstr "The postponed flag was removed from the match."
 
 msgid "matches.update-match-date.success"
 msgstr "Successfully changed match date."
@@ -7036,6 +7057,12 @@ msgstr "Changed the match date for %1%2."
 
 msgid "system-event-log.description.venue-change"
 msgstr "Changed the venue for %1%2."
+
+msgid "system-event-log.description.postpone"
+msgstr "Postponed %1%2."
+
+msgid "system-event-log.description.postpone-unset"
+msgstr "Cancelled the postponement for %1%2."
 
 msgid "system-event-log.description.handicap-change"
 msgstr "Changed the handicap for %1%2."

--- a/root/templates/html/matches/team/update.ttkt
+++ b/root/templates/html/matches/team/update.ttkt
@@ -7,6 +7,14 @@ away_team_html = match.team_season_away_team_season.full_name | html_entity;
 <fieldset>
   <legend>[% c.maketext("matches.update.form.legend.match-details") %]</legend>
   
+[%
+IF match.postponed;
+  SET postponed_checked = ' checked="checked"';
+ELSE;
+  SET postponed_checked = '';
+END;
+-%]
+  <input type="checkbox" id="postpone" name="postpone" data-label="[% c.maketext("matches.field.postpone") %]" value="1"[% postponed_checked %] />
   <div class="label-field-container">
     <label for="played-date">[% c.maketext("matches.field.date") %]</label>
     <div class="field-container">

--- a/root/templates/scripts/matches/team/update.ttjs
+++ b/root/templates/scripts/matches/team/update.ttjs
@@ -304,6 +304,37 @@ END;
   }); // End of accordion / sortable init
   
   /**
+   *  Change event for setting the posponed flag
+   *
+   */
+   var disable_postpone_call = false;
+  $("#postpone").on("change", function() {
+    if ( disable_postpone_call === false ) {
+      $.ajax({
+        url: "[% c.uri_for_action("/matches/team/set_postponed_by_ids", [match.team_season_home_team_season.team.id, match.team_season_away_team_season.team.id, match.scheduled_date.year, match_month, match_day]) %]",
+        type: "POST",
+        dataType: "json",
+        data: {postponed: $(this).prop("checked") ? 1 : 0},
+        success: function(response) {
+          show_messages(response);
+        },
+        error: function(xhr, ajax_options, thrown_error) { 
+          if ( typeof xhr.responseJSON === "undefined" ) {
+            $().toastmessage("showToast", {
+              text: "<br />" + thrown_error + ": [% c.maketext("ajax.error.refresh-advice") %]",
+              sticky: true,
+              position: "top-center",
+              type: "error"
+            });
+          } else {
+            show_messages(xhr.responseJSON);
+          }
+        }
+      });
+    }
+  }); // End of postponed checkbox handler
+  
+  /**
    *  Change event for changing the date
    *
    */
@@ -315,6 +346,9 @@ END;
       data: {date: $(this).val()},
       success: function(response) {
         show_messages(response);
+        disable_postpone_call = true;
+        $("#postpone").prettyCheckable("uncheck");
+        disable_postpone_call = false;
       },
       error: function(xhr, ajax_options, thrown_error) { 
         if ( typeof xhr.responseJSON === "undefined" ) {
@@ -635,6 +669,9 @@ END;
                     window.location.href = response.redirect_uri;
                   } else {
                     show_messages(response);
+                    disable_postpone_call = true;
+                    $("#postpone").prettyCheckable("uncheck");
+                    disable_postpone_call = false;
                     
                     // Move on to the next one (if there is one)
                     if ( active_game_number < total_games && t.data("player-location") == "away" ) {


### PR DESCRIPTION
- **[New]** Match postponement flag, checkbox from the match update page.
- **[New]** Successfully changing the match date or score automatically unsets the postponed flag, since if the match is being played or we know the new date, it doesn't need to be marked as postponed any more.
- **[New]** TeamMatch result method 'score' now uses the postponement flag to show a message about the match being postponed, before it says 'not yet received'.
- **[New]** - Changed "errors" and "warnings" hash keys to singular forms "error", "warning".  This has resulted in a large number of changed files for this update, but it was necessary to allow us to use the keys directly from the can_update routine.