### PR TITLE
Match update log enhancements

### DIFF
--- a/lib/TopTable/Controller/Matches/Team.pm
+++ b/lib/TopTable/Controller/Matches/Team.pm
@@ -522,10 +522,7 @@ sub update_game_score :Private {
   
   if ( $response->{completed} ) {
     # Completed, log that we updated the match
-    my $match_name = $c->maketext("matches.name", $match->team_season_home_team_season->full_name, $match->team_season_away_team_season->full_name);
-    $match_name .= " (" . $match->tournament_round->tournament->event_season->name . ")" if defined($match->tournament_round);
-    
-    $c->forward("TopTable::Controller::SystemEventLog", "add_event", ["team-match", "update", {home_team => $match->team_season_home_team_season->team->id, away_team => $match->team_season_away_team_season->team->id, scheduled_date => $match->scheduled_date->ymd}, $match_name]);
+    $c->forward("TopTable::Controller::SystemEventLog", "add_event", ["team-match", "update", {home_team => $match->team_season_home_team_season->team->id, away_team => $match->team_season_away_team_season->team->id, scheduled_date => $match->scheduled_date->ymd}, $match->name_with_competition]);
   } else {
     # Wasn't completed, return with an error code
     $c->res->status(400);

--- a/root/templates/html/matches/team/view.ttkt
+++ b/root/templates/html/matches/team/view.ttkt
@@ -301,6 +301,7 @@ IF match.started;
               <td>[% c.maketext("matches.game.score.not-yet-updated") %]</td>
               <td>&nbsp;</td>
               <td>&nbsp;</td>
+              <td>&nbsp;</td>
 [%
     END;
 -%]


### PR DESCRIPTION
- **[New]** TeamMatch result method name_with_competition to give the name of the match along with competition (division or tournament name, with round or group).
- **[New]** New method above used in logging match update events.
- **[Fix]** Partially updated matches showed the wrong number of columns in incomplete games due to the extra column being added for score for completed games.