### PR TITLE
Missing players in handicapped matches adjustment

### DIFF
--- a/lib/TopTable/Controller/Matches/Team.pm
+++ b/lib/TopTable/Controller/Matches/Team.pm
@@ -261,10 +261,10 @@ sub view :Private {
   my $hcp_flag = $match->handicapped ? "/hcp" : "";
   if ( $match->started ) {
     # The match has started, we don't specify a tab and it will default to the first one (games)
-    push(@external_scripts, $c->uri_for("/static/script/matches/team$tourn_flag$hcp_flag/view.js", {v => 4}));
+    push(@external_scripts, $c->uri_for("/static/script/matches/team$tourn_flag$hcp_flag/view.js", {v => 5}));
   } else {
     # The match has not started, start on the match details tab
-    push(@external_scripts, $c->uri_for("/static/script/matches/team$tourn_flag$hcp_flag/view-not-started.js", {v => 4}));
+    push(@external_scripts, $c->uri_for("/static/script/matches/team$tourn_flag$hcp_flag/view-not-started.js", {v => 5}));
   }
   
   # Inform that the scorecard is not yet complete if it's started but not complete

--- a/lib/TopTable/Schema/Result/TeamMatchPlayer.pm
+++ b/lib/TopTable/Schema/Result/TeamMatchPlayer.pm
@@ -1073,7 +1073,7 @@ sub update_person {
             $stat->legs_played ? $stat->average_leg_wins(( $stat->legs_won / $stat->legs_played ) * 100)  : $stat->average_leg_wins(0);
             $stat->points_played ? $stat->average_point_wins(( $stat->points_won / $stat->points_played ) * 100)  : $stat->average_point_wins(0);
           }
-            
+          
           $stat->update;
         }
       }
@@ -1088,7 +1088,7 @@ sub update_person {
       
       foreach my $stat ( @new_player_stats ) {
         # We know the match has started, and since this is a new player in the match, we have to add 1 to matches played.
-        $stat->update({matches_played => $stat->matches_played + 1});
+        $stat->matches_played($stat->matches_played + 1);
         
         if ( $match->complete ) {
           # Matches won / lost / drawn need to be worked out if the match is complete
@@ -1115,6 +1115,8 @@ sub update_person {
             $stat->matches_drawn($stat->matches_drawn + 1);
           }
         }
+        
+        $stat->update;
       }
     }
     

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -3202,6 +3202,9 @@ msgstr "Points won"
 msgid "matches.summaries.heading.points-average"
 msgstr "Points average (%)"
 
+msgid "matches.summaries.heading.points-difference"
+msgstr "Points difference"
+
 msgid "matches.link-title.team-tournament"
 msgstr "View the %2 statistics for %1"
 

--- a/root/static/script/matches/team/hcp/view-not-started.js
+++ b/root/static/script/matches/team/hcp/view-not-started.js
@@ -13,14 +13,31 @@ $(document).ready(function(){
     ordering: false,
     fixedHeader: true,
     searching: false,
-    columns: [
-      {responsivePriority: 1}, // Team
-      {responsivePriority: 2}, // Handicap
-      {responsivePriority: 4}, // Legs won
-      {responsivePriority: 3}, // Legs average
-      {responsivePriority: 6}, // Points won
-      {responsivePriority: 5} // Points average
-    ]
+    columnDefs: [{
+      // Team
+      targets: 0,
+      responsivePriority: 1
+    }, {
+      // Handicap
+      targets: 1,
+      responsivePriority: 2
+    }, {
+      // Legs won
+      targets: 2,
+      responsivePriority: 4
+    }, {
+      // Legs average
+      targets: 3,
+      responsivePriority: 3
+    }, {
+      // Points won
+      targets: 4,
+      responsivePriority: 6
+    }, {
+      // Points won
+      targets: 4,
+      responsivePriority: 5
+    }]
   });
   
   /*

--- a/root/static/script/matches/team/hcp/view.js
+++ b/root/static/script/matches/team/hcp/view.js
@@ -29,14 +29,31 @@ $(document).ready(function(){
     ordering: false,
     fixedHeader: true,
     searching: false,
-    columns: [
-      {responsivePriority: 1}, // Team
-      {responsivePriority: 2}, // Handicap
-      {responsivePriority: 4}, // Legs won
-      {responsivePriority: 3}, // Legs average
-      {responsivePriority: 6}, // Points won
-      {responsivePriority: 5} // Points average
-    ]
+    columnDefs: [{
+      // Team
+      targets: 0,
+      responsivePriority: 1
+    }, {
+      // Handicap
+      targets: 1,
+      responsivePriority: 2
+    }, {
+      // Legs won
+      targets: 2,
+      responsivePriority: 4
+    }, {
+      // Legs average
+      targets: 3,
+      responsivePriority: 3
+    }, {
+      // Points won
+      targets: 4,
+      responsivePriority: 6
+    }, {
+      // Points won
+      targets: 4,
+      responsivePriority: 5
+    }]
   });
   
   var players_table = $("#players-table").DataTable({

--- a/root/static/script/matches/team/tourn/hcp/view-not-started.js
+++ b/root/static/script/matches/team/tourn/hcp/view-not-started.js
@@ -13,15 +13,35 @@ $(document).ready(function(){
     ordering: false,
     fixedHeader: true,
     searching: false,
-    columns: [
-      {responsivePriority: 1}, // Team
-      {responsivePriority: 2}, // Division
-      {responsivePriority: 3}, // Handicap
-      {responsivePriority: 5}, // Legs won
-      {responsivePriority: 4}, // Legs average
-      {responsivePriority: 7}, // Points won
-      {responsivePriority: 6} // Points average
-    ]
+    columnDefs: [{
+      // Team
+      targets: 0,
+      responsivePriority: 1
+    }, {
+      // Division
+      targets: 1,
+      responsivePriority: 2
+    }, {
+      // Handicap
+      targets: 2,
+      responsivePriority: 3
+    }, {
+      // Legs won
+      targets: 3,
+      responsivePriority: 5
+    }, {
+      // Legs average
+      targets: 4,
+      responsivePriority: 4
+    }, {
+      // Points won
+      targets: 5,
+      responsivePriority: 7
+    }, {
+      // Points won
+      targets: 6,
+      responsivePriority: 6
+    }]
   });
   
   /*

--- a/root/static/script/matches/team/tourn/hcp/view.js
+++ b/root/static/script/matches/team/tourn/hcp/view.js
@@ -29,15 +29,35 @@ $(document).ready(function(){
     ordering: false,
     fixedHeader: true,
     searching: false,
-    columns: [
-      {responsivePriority: 1}, // Team
-      {responsivePriority: 2}, // Division
-      {responsivePriority: 3}, // Handicap
-      {responsivePriority: 5}, // Legs won
-      {responsivePriority: 4}, // Legs average
-      {responsivePriority: 7}, // Points won
-      {responsivePriority: 6} // Points average
-    ]
+    columnDefs: [{
+      // Team
+      targets: 0,
+      responsivePriority: 1
+    }, {
+      // Division
+      targets: 1,
+      responsivePriority: 2
+    }, {
+      // Handicap
+      targets: 2,
+      responsivePriority: 3
+    }, {
+      // Legs won
+      targets: 3,
+      responsivePriority: 5
+    }, {
+      // Legs average
+      targets: 4,
+      responsivePriority: 4
+    }, {
+      // Points won
+      targets: 5,
+      responsivePriority: 7
+    }, {
+      // Points won
+      targets: 6,
+      responsivePriority: 6
+    }]
   });
   
   var players_table = $("#players-table").DataTable({

--- a/root/static/script/matches/team/tourn/view-not-started.js
+++ b/root/static/script/matches/team/tourn/view-not-started.js
@@ -13,14 +13,31 @@ $(document).ready(function(){
     ordering: false,
     fixedHeader: true,
     searching: false,
-    columns: [
-      {responsivePriority: 1}, // Team
-      {responsivePriority: 2}, // Division
-      {responsivePriority: 4}, // Legs won
-      {responsivePriority: 3}, // Legs average
-      {responsivePriority: 6}, // Points won
-      {responsivePriority: 5} // Points average
-    ]
+    columnDefs: [{
+      // Team
+      targets: 0,
+      responsivePriority: 1
+    }, {
+      // Division
+      targets: 1,
+      responsivePriority: 2
+    }, {
+      // Legs won
+      targets: 2,
+      responsivePriority: 4
+    }, {
+      // Legs average
+      targets: 3,
+      responsivePriority: 3
+    }, {
+      // Points won
+      targets: 4,
+      responsivePriority: 6
+    }, {
+      // Points average
+      targets: 5,
+      responsivePriority: 5
+    }]
   });
   
   /*

--- a/root/static/script/matches/team/tourn/view.js
+++ b/root/static/script/matches/team/tourn/view.js
@@ -29,14 +29,31 @@ $(document).ready(function(){
     ordering: false,
     fixedHeader: true,
     searching: false,
-    columns: [
-      {responsivePriority: 1}, // Team
-      {responsivePriority: 2}, // Division
-      {responsivePriority: 4}, // Legs won
-      {responsivePriority: 3}, // Legs average
-      {responsivePriority: 6}, // Points won
-      {responsivePriority: 5} // Points average
-    ]
+    columnDefs: [{
+      // Team
+      targets: 0,
+      responsivePriority: 1
+    }, {
+      // Division
+      targets: 1,
+      responsivePriority: 2
+    }, {
+      // Legs won
+      targets: 2,
+      responsivePriority: 4
+    }, {
+      // Legs average
+      targets: 3,
+      responsivePriority: 3
+    }, {
+      // Points won
+      targets: 4,
+      responsivePriority: 6
+    }, {
+      // Points average
+      targets: 5,
+      responsivePriority: 5
+    }]
   });
   
   var players_table = $("#players-table").DataTable({

--- a/root/static/script/matches/team/view-not-started.js
+++ b/root/static/script/matches/team/view-not-started.js
@@ -13,13 +13,27 @@ $(document).ready(function(){
     ordering: false,
     fixedHeader: true,
     searching: false,
-    columns: [
-      {responsivePriority: 1}, // Team
-      {responsivePriority: 3}, // Legs won
-      {responsivePriority: 2}, // Legs average
-      {responsivePriority: 5}, // Points won
-      {responsivePriority: 4} // Points average
-    ]
+    columnDefs: [{
+      // Game number
+      targets: 0,
+      responsivePriority: 5
+    }, {
+      // Result (X beat Y)
+      targets: 1,
+      responsivePriority: 1
+    }, {
+      // Detailed scores
+      targets: 2,
+      responsivePriority: 3
+    }, {
+      // Score (3-1)
+      targets: 3,
+      responsivePriority: 2
+    }, {
+      // Match score
+      targets: 4,
+      responsivePriority: 4
+    }]
   });
   
   /*

--- a/root/static/script/matches/team/view.js
+++ b/root/static/script/matches/team/view.js
@@ -13,13 +13,27 @@ $(document).ready(function(){
     ordering: false,
     fixedHeader: true,
     searching: false,
-    columns: [
-      {responsivePriority: 5}, // Game number
-      {responsivePriority: 1}, // Result (X beat Y)
-      {responsivePriority: 3}, // Detailed scores
-      {responsivePriority: 2}, // Score (3-1)
-      {responsivePriority: 4} // Match score
-    ]
+    columnDefs: [{
+      // Game number
+      targets: 0,
+      responsivePriority: 5
+    }, {
+      // Result (X beat Y)
+      targets: 1,
+      responsivePriority: 1
+    }, {
+      // Detailed scores
+      targets: 2,
+      responsivePriority: 3
+    }, {
+      // Score (3-1)
+      targets: 3,
+      responsivePriority: 2
+    }, {
+      // Match score
+      targets: 4,
+      responsivePriority: 4
+    }]
   });
   
   var teams_table = $("#teams-table").DataTable({

--- a/root/templates/html/fixtures-results/view/hcp/by-team.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/by-team.ttkt
@@ -109,7 +109,7 @@ END;
     <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-away") %]">[% location_text %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.opponent") %]"><a title="[% opponent_uri_title %]" href="[% opponent_uri %]">[% opponent_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.hcp") %]">[% match.relative_handicap(location) %]</td>
+    <td data-label="[% c.maketext("fixtures-results.heading.hcp") %]">[% match.relative_handicap_text(location) %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.result") %]">[% match_result.result OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>

--- a/root/templates/html/matches/team/view.ttkt
+++ b/root/templates/html/matches/team/view.ttkt
@@ -411,6 +411,14 @@ END;
               <th class="numeric">[% c.maketext("matches.summaries.heading.legs-average") %]</th>
               <th class="numeric">[% c.maketext("matches.summaries.heading.points-won") %]</th>
               <th class="numeric">[% c.maketext("matches.summaries.heading.points-average") %]</th>
+[%
+IF match.handicapped;
+  # Points difference column, as this may have been calculated
+-%]
+              <th class="numeric">[% c.maketext("matches.summaries.heading.points-difference") %]</th>
+[%
+END;
+-%]
             </tr>
           </thead>
           <tbody>
@@ -432,6 +440,14 @@ END;
               <td data-label="[% c.maketext("matches.summaries.heading.legs-average") %]" class="numeric">[% match.home_team_average_leg_wins | format('%.2f') %]</td>
               <td data-label="[% c.maketext("matches.summaries.heading.points-won") %]" class="numeric">[% match.home_team_points_won %]</td>
               <td data-label="[% c.maketext("matches.summaries.heading.points-average") %]" class="numeric">[% match.home_team_average_point_wins | format('%.2f') %]</td>
+[%
+IF match.handicapped;
+  # Points difference column, as this may have been calculated
+-%]
+              <td data-label="[% c.maketext("matches.summaries.heading.points-difference") %]" class="numeric">[% match.home_team_points_difference %]</td>
+[%
+END;
+-%]
             </tr>
             <tr>
               <td data-label="[% c.maketext("matches.summaries.heading.team") %]"><a title="[% away_uri_title %]" href="[% away_uri %]">[% away_team_html %]</a></td>
@@ -451,6 +467,14 @@ END;
               <td data-label="[% c.maketext("matches.summaries.heading.legs-average") %]" class="numeric">[% match.away_team_average_leg_wins | format('%.2f') %]</td>
               <td data-label="[% c.maketext("matches.summaries.heading.points-won") %]" class="numeric">[% match.away_team_points_won %]</td>
               <td data-label="[% c.maketext("matches.summaries.heading.points-average") %]" class="numeric">[% match.away_team_average_point_wins | format('%.2f') %]</td>
+[%
+IF match.handicapped;
+  # Points difference column, as this may have been calculated
+-%]
+              <td data-label="[% c.maketext("matches.summaries.heading.points-difference") %]" class="numeric">[% match.away_team_points_difference %]</td>
+[%
+END;
+-%]
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
- **[New]** Added home_team_points_difference and away_team_points_difference columns to team_matches database - previously these were calculated in full each time for the team_seasons / tournament_teams / tournament_round_teams tables; now we calculate for each match and add / subtract from the existing values in those tables.  This also allows for points difference adjustments per match (if games are awarded).
- **[New]** Added points difference column to the teams table in the match view page.
- **[New]** TeamMatch relative_handicap method renamed relative_handicap_text; new method relative_handicap to give just the number and not worry about 'scratch', 'not set', etc.
- **[New]** Adjustment to team handicap by a percentage of the handicap if any games are awarded and not started.
- **[Fix]** TeamMatchPlayer result method update_person had issues updating stats for new player set.