### PR TITLE
Fix to match cancellation points difference

### DIFF
--- a/lib/TopTable/Controller/Events.pm
+++ b/lib/TopTable/Controller/Events.pm
@@ -1288,6 +1288,8 @@ sub rounds :Private {
     subtitle2 => $enc_event_name,
     subtitle2_uri => {link => $event_link, title => $c->maketext("title.link.text.view-event", $enc_event_name)},
     round => $round,
+    match_template => $round->match_template,
+    rank_template => $round->rank_template,
   });
 }
 
@@ -1612,15 +1614,24 @@ sub do_add_next_round :Chained("base_current_season") :PathPart("do-add-next-rou
 #   my $event_type = $c->stash->{event_type};
 #   my $tournament = $c->stash->{event_detail};
 #   my $round = $c->stash->{round};
+#   my $prev_round = $round->prev_round;
+#   my $match_template = $prev_round->match_template;
+#   my $ranking_template = $prev_round->rank_template;
   
 #   # Check that we are authorised to edit events
 #   $c->forward("TopTable::Controller::Users", "check_authorisation", ["event_edit", $c->maketext("user.auth.edit-events"), 1]);
   
 #   my %can = $round->can_update("entrants");
   
+#   my $js = "select-entrants";
+#   $js .= "-points" if $ranking_template->assign_points;
+#   $js .= "-hcp" if $match_template->handicapped;
+#   $js = $c->uri_for("/static/script/events/tournaments/rounds/$js.js");
+  
 #   # Setup template and scripts
 #   $c->stash({
 #     template => "html/events/tournaments/rounds/select-entrants.ttkt",
+#     form_action => $c->uri_for_action("/events/do_round_select_entrants", [$event->url_key, $round->url_key]),
 #     external_scripts => [
 #       $c->uri_for("/static/script/plugins/chosen/chosen.jquery.min.js"),
 #       $c->uri_for("/static/script/standard/chosen.js"),
@@ -1629,7 +1640,9 @@ sub do_add_next_round :Chained("base_current_season") :PathPart("do-add-next-rou
 #       $c->uri_for("/static/script/plugins/datatables/dataTables.fixedHeader.min.js"),
 #       $c->uri_for("/static/script/plugins/datatables/dataTables.responsive.min.js"),
 #       $c->uri_for("/static/script/plugins/datatables/dataTables.rowGroup.min.js"),
-#       $c->uri_for("/static/script/events/tournaments/rounds/select-entrants.js"),
+#       $c->uri_for("/static/script/plugins/prettycheckable/prettyCheckable.min.js"),
+#       $c->uri_for("/static/script/standard/prettycheckable.js"),
+#       $js,
 #     ],
 #     external_styles => [
 #       $c->uri_for("/static/css/chosen/chosen.min.css"),
@@ -1638,28 +1651,34 @@ sub do_add_next_round :Chained("base_current_season") :PathPart("do-add-next-rou
 #       $c->uri_for("/static/css/datatables/fixedHeader.dataTables.min.css"),
 #       $c->uri_for("/static/css/datatables/responsive.dataTables.min.css"),
 #       $c->uri_for("/static/css/datatables/rowGroup.dataTables.min.css"),
+#       $c->uri_for("/static/css/prettycheckable/prettyCheckable.css"),
 #     ],
 #     view_online_display => "Selecting entrants for $enc_event_name",
 #     view_online_link => 0,
-#     automatic_qualifiers => $round->automatic_qualifiers,
+#     prev_round => $prev_round,
+#     auto_qualifiers => [$prev_round->auto_qualifiers],
+#     non_auto_qualifiers => [$prev_round->non_auto_qualifiers],
+#     winner_type => $match_template->winner_type->id,
+#     match_template => $match_template,
+#     ranking_template => $ranking_template,
 #   });
 # }
 
-=head2 do_round_select_entrants
+# =head2 do_round_select_entrants
 
-Process the form to add the entrants to a round.
+# Process the form to add the entrants to a round.
 
-=cut
+# =cut
 
-sub do_round_select_entrants :Chained("rounds_current_season") :PathPart("do-select-entrants") :Args(0) {
-  my ( $self, $c ) = @_;
+# sub do_round_select_entrants :Chained("rounds_current_season") :PathPart("do-select-entrants") :Args(0) {
+#   my ( $self, $c ) = @_;
   
-  # Check that we are authorised to edit events
-  $c->forward("TopTable::Controller::Users", "check_authorisation", ["event_edit", $c->maketext("user.auth.edit-events"), 1]);
+#   # Check that we are authorised to edit events
+#   $c->forward("TopTable::Controller::Users", "check_authorisation", ["event_edit", $c->maketext("user.auth.edit-events"), 1]);
   
-  # Forward to the create / edit routine
-  $c->detach("process_form", [qw( round entrants )]);
-}
+#   # Forward to the create / edit routine
+#   $c->detach("process_form", [qw( round entrants )]);
+# }
 
 =head2 prepare_form_round
 

--- a/lib/TopTable/Controller/Matches/Team.pm
+++ b/lib/TopTable/Controller/Matches/Team.pm
@@ -1010,7 +1010,7 @@ sub do_cancel :Private {
   # Now forward to the match cancellation routine, which does all the error checking
   my $response = $cancel
     ? $match->cancel({home_points_awarded => $home_points_awarded, away_points_awarded => $away_points_awarded, logger => sub{ my $level = shift; $c->log->$level( @_ ); }})
-    : $match->uncancel;
+    : $match->uncancel({logger => sub{ my $level = shift; $c->log->$level( @_ ); }});
   
   # Set the status messages we need to show on redirect
   my @errors = @{$response->{error}};

--- a/lib/TopTable/Schema/Result/TournamentRoundDoubles.pm
+++ b/lib/TopTable/Schema/Result/TournamentRoundDoubles.pm
@@ -514,6 +514,28 @@ sub object_name2 {
   return $self->tournament_pair->season_pair->person_season_person2_season_team->display_name;
 }
 
+=head2 group_position
+
+Get the group position for the team (return undef if there's no group).
+
+=cut
+
+sub group_position {
+  my $self = shift;
+  
+  my $group = $self->tournament_group;
+  return undef unless defined($group);
+  my @entrants = $group->get_entrants_in_table_order;
+  
+  my $pos = 0;
+  # Loop through entrants until we find the current team (IDs match)
+  foreach my $entrant ( @entrants ) {
+    # Increment the position so we know which position we're in and can return that number
+    $pos++;
+    return $pos if $entrant->id == $self->id;
+  }
+}
+
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/TopTable/Schema/Result/TournamentRoundGroup.pm
+++ b/lib/TopTable/Schema/Result/TournamentRoundGroup.pm
@@ -706,57 +706,11 @@ sub get_entrants_in_table_order {
   my $match_template = $tourn_round->match_template;
   
   # Setup the initial sort attribs
-  my %attrib;
+  my %attrib = (
+    order_by => $self->tournament_round->get_table_order_attribs,
+  );
   
   if ( $entry_type eq "team" ) {
-    my $winner_type = $match_template->winner_type->id;
-    
-    if ( $rank_template->assign_points ) {
-      if ( $winner_type eq "games" ) {
-        %attrib = (
-          order_by => [{
-            -desc => [qw( me.table_points me.games_won me.matches_won me.matches_drawn me.matches_played )],
-          }, {
-            -asc  => [qw( me.games_lost me.matches_lost )],
-          }, {
-            -desc => [qw( me.games_won )],
-          }, {
-            -asc => [qw( club_season.short_name team_season.name )]
-          }]
-        );
-      } else {
-        %attrib = (
-          order_by => [{
-            -desc => [qw( me.table_points me.points_difference me.points_won me.matches_played )],
-          }, {
-            -asc  => [qw( me.points_lost me.matches_lost club_season.short_name team_season.name )],
-          }]
-        );
-      }
-    } else {
-      if ( $winner_type eq "games" ) {
-        %attrib = (
-          order_by => [{
-            -desc => [qw( me.games_won me.matches_won me.matches_drawn me.matches_played )],
-          }, {
-            -asc  => [qw( me.games_lost me.matches_lost )],
-          }, {
-            -desc => [qw( me.games_won )],
-          }, {
-            -asc => [qw( club_season.short_name team_season.name )]
-          }]
-        );
-      } else {
-        %attrib = (
-          order_by => [{
-            -desc => [qw( me.points_difference me.points_won me.matches_played )],
-          }, {
-            -asc  => [qw( me.points_lost me.matches_lost club_season.short_name team_season.name )],
-          }]
-        );
-      }
-    }
-    
     $member_rel = "tournament_round_teams";
     
     if ( $prefetch_group ) {

--- a/lib/TopTable/Schema/Result/TournamentRoundPerson.pm
+++ b/lib/TopTable/Schema/Result/TournamentRoundPerson.pm
@@ -762,6 +762,28 @@ sub object_name {
   return $self->tournament_person->person_season->display_name;
 }
 
+=head2 group_position
+
+Get the group position for the player (return undef if there's no group).
+
+=cut
+
+sub group_position {
+  my $self = shift;
+  
+  my $group = $self->tournament_group;
+  return undef unless defined($group);
+  my @entrants = $group->get_entrants_in_table_order;
+  
+  my $pos = 0;
+  # Loop through entrants until we find the current team (IDs match)
+  foreach my $entrant ( @entrants ) {
+    # Increment the position so we know which position we're in and can return that number
+    $pos++;
+    return $pos if $entrant->id == $self->id;
+  }
+}
+
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/TopTable/Schema/Result/TournamentRoundTeam.pm
+++ b/lib/TopTable/Schema/Result/TournamentRoundTeam.pm
@@ -925,6 +925,28 @@ sub adjust_points {
   return $response;
 }
 
+=head2 group_position
+
+Get the group position for the team (return undef if there's no group).
+
+=cut
+
+sub group_position {
+  my $self = shift;
+  
+  my $group = $self->tournament_group;
+  return undef unless defined($group);
+  my @entrants = $group->get_entrants_in_table_order;
+  
+  my $pos = 0;
+  # Loop through entrants until we find the current team (IDs match)
+  foreach my $entrant ( @entrants ) {
+    # Increment the position so we know which position we're in and can return that number
+    $pos++;
+    return $pos if $entrant->id == $self->id;
+  }
+}
+
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;
 1;

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -4181,6 +4181,21 @@ msgstr "Venue"
 msgid "events.tournaments.rounds.venue-use-home-team"
 msgstr "Home team&#39;s venue"
 
+msgid "events.legend.tournament.round.selec-entrants.auto"
+msgstr "Automatic qualifiers (you cannot change these)"
+
+msgid "events.legend.tournament.round.selec-entrants.manual"
+msgstr "Best runners up (select these from the list)"
+
+msgid "events.tournament.rounds.entrants.group"
+msgstr "Group"
+
+msgid "events.tournament.rounds.entrants.select"
+msgstr "Selection"
+
+msgid "events.tournament.rounds.entrants.group-pos"
+msgstr "Group position"
+
 ### Reports
 msgid "reports.name.loan-players"
 msgstr "Loan players"

--- a/root/static/script/events/tournaments/rounds/select-entrants-points-hcp.js
+++ b/root/static/script/events/tournaments/rounds/select-entrants-points-hcp.js
@@ -1,0 +1,134 @@
+/**
+ *  Initialise datatable
+ *
+ */
+$(document).ready(function() {
+  $("#auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: 10,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Group
+      responsivePriority: 11,
+      targets: 0
+    }, {
+      // Group position
+      responsivePriority: 2,
+      targets: 1
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 1,
+      targets: 2
+    }, {
+      // Matches played
+      responsivePriority: 8,
+      targets: 3
+    }, {
+      // Won
+      responsivePriority: 7,
+      targets: 4
+    }, {
+      // Drawn
+      responsivePriority: 10,
+      targets: 5
+    }, {
+      // Lost
+      responsivePriority: 9,
+      targets: 6
+    }, {
+      // For
+      responsivePriority: 5,
+      targets: 7
+    }, {
+      // Against
+      responsivePriority: 6,
+      targets: 8
+    }, {
+      // Handicap
+      responsivePriority: 12,
+      targets: 9
+    }, {
+      // Points / games difference
+      responsivePriority: 4,
+      targets: 10
+    }, {
+      // Points
+      responsivePriority: 3,
+      targets: 11
+    }]
+  });
+  
+  $("#non-auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: -1,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Group
+      responsivePriority: 11,
+      targets: 0
+    }, {
+      // Group position
+      responsivePriority: 2,
+      targets: 1
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 1,
+      targets: 2
+    }, {
+      // Matches played
+      responsivePriority: 8,
+      targets: 3
+    }, {
+      // Won
+      responsivePriority: 7,
+      targets: 4
+    }, {
+      // Drawn
+      responsivePriority: 10,
+      targets: 5
+    }, {
+      // Lost
+      responsivePriority: 9,
+      targets: 6
+    }, {
+      // For
+      responsivePriority: 5,
+      targets: 7
+    }, {
+      // Against
+      responsivePriority: 6,
+      targets: 8
+    }, {
+      // Handicap
+      responsivePriority: 12,
+      targets: 9
+    }, {
+      // Points / games difference
+      responsivePriority: 4,
+      targets: 10
+    }, {
+      // Points
+      responsivePriority: 3,
+      targets: 11
+    }]
+  });
+  
+  $("select[name=auto-table_length], select[name=non-auto-table_length]").chosen({
+    disable_search: true,
+    single_backstroke_delete: false,
+    allow_single_deselect: true,
+    width: "75px"
+  });
+});

--- a/root/static/script/events/tournaments/rounds/select-entrants-points.js
+++ b/root/static/script/events/tournaments/rounds/select-entrants-points.js
@@ -1,0 +1,126 @@
+/**
+ *  Initialise datatable
+ *
+ */
+$(document).ready(function() {
+  $("#auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: 10,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Group
+      responsivePriority: 11,
+      targets: 0
+    }, {
+      // Group position
+      responsivePriority: 2,
+      targets: 1
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 1,
+      targets: 2
+    }, {
+      // Matches played
+      responsivePriority: 8,
+      targets: 3
+    }, {
+      // Won
+      responsivePriority: 7,
+      targets: 4
+    }, {
+      // Drawn
+      responsivePriority: 10,
+      targets: 5
+    }, {
+      // Lost
+      responsivePriority: 9,
+      targets: 6
+    }, {
+      // For
+      responsivePriority: 5,
+      targets: 7
+    }, {
+      // Against
+      responsivePriority: 6,
+      targets: 8
+    }, {
+      // Points / games difference
+      responsivePriority: 4,
+      targets: 9
+    }, {
+      // Points
+      responsivePriority: 3,
+      targets: 10
+    }]
+  });
+  
+  $("#non-auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: -1,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Group
+      responsivePriority: 11,
+      targets: 0
+    }, {
+      // Group position
+      responsivePriority: 2,
+      targets: 1
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 1,
+      targets: 2
+    }, {
+      // Matches played
+      responsivePriority: 8,
+      targets: 3
+    }, {
+      // Won
+      responsivePriority: 7,
+      targets: 4
+    }, {
+      // Drawn
+      responsivePriority: 10,
+      targets: 5
+    }, {
+      // Lost
+      responsivePriority: 9,
+      targets: 6
+    }, {
+      // For
+      responsivePriority: 5,
+      targets: 7
+    }, {
+      // Against
+      responsivePriority: 6,
+      targets: 8
+    }, {
+      // Points / games difference
+      responsivePriority: 4,
+      targets: 9
+    }, {
+      // Points
+      responsivePriority: 3,
+      targets: 10
+    }]
+  });
+  
+  $("select[name=auto-table_length], select[name=non-auto-table_length]").chosen({
+    disable_search: true,
+    single_backstroke_delete: false,
+    allow_single_deselect: true,
+    width: "75px"
+  });
+});

--- a/root/static/script/events/tournaments/rounds/select-entrants.js
+++ b/root/static/script/events/tournaments/rounds/select-entrants.js
@@ -1,0 +1,118 @@
+/**
+ *  Initialise datatable
+ *
+ */
+$(document).ready(function() {
+  $("#auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: 10,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Group
+      responsivePriority: 11,
+      targets: 0
+    }, {
+      // Group position
+      responsivePriority: 2,
+      targets: 1
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 1,
+      targets: 2
+    }, {
+      // Matches played
+      responsivePriority: 9,
+      targets: 3
+    }, {
+      // Won
+      responsivePriority: 6,
+      targets: 4
+    }, {
+      // Drawn
+      responsivePriority: 8,
+      targets: 5
+    }, {
+      // Lost
+      responsivePriority: 7,
+      targets: 6
+    }, {
+      // For
+      responsivePriority: 4,
+      targets: 7
+    }, {
+      // Against
+      responsivePriority: 5,
+      targets: 8
+    }, {
+      // Points / games difference
+      responsivePriority: 3,
+      targets: 9
+    }]
+  });
+  
+  $("#non-auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: -1,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Group
+      responsivePriority: 11,
+      targets: 0
+    }, {
+      // Group position
+      responsivePriority: 2,
+      targets: 1
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 1,
+      targets: 2
+    }, {
+      // Matches played
+      responsivePriority: 9,
+      targets: 3
+    }, {
+      // Won
+      responsivePriority: 6,
+      targets: 4
+    }, {
+      // Drawn
+      responsivePriority: 8,
+      targets: 5
+    }, {
+      // Lost
+      responsivePriority: 7,
+      targets: 6
+    }, {
+      // For
+      responsivePriority: 4,
+      targets: 7
+    }, {
+      // Against
+      responsivePriority: 5,
+      targets: 8
+    }, {
+      // Points / games difference
+      responsivePriority: 3,
+      targets: 9
+    }]
+  });
+  
+  $("select[name=auto-table_length], select[name=non-auto-table_length]").chosen({
+    disable_search: true,
+    single_backstroke_delete: false,
+    allow_single_deselect: true,
+    width: "75px"
+  });
+});

--- a/root/templates/html/events/tournaments/rounds/select-entrants.ttkt
+++ b/root/templates/html/events/tournaments/rounds/select-entrants.ttkt
@@ -1,0 +1,147 @@
+<form action="[% form_action %]">
+<fieldset>
+  <legend>[% c.maketext("events.legend.tournament.round.selec-entrants.auto") %]</legend>
+  <div class="table-wrap">
+    <div class="table-layout table-layout-centre">
+      <table class="stripe hover row-border" id="auto-table">
+        <thead>
+          <tr>
+            <th>[% c.maketext("events.tournament.rounds.entrants.group") %]</th>
+            <th>[% c.maketext("events.tournament.rounds.entrants.group-pos") %]</th>
+            <th>[% c.maketext("stats.table-heading.team") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading.team-matches-played.full") %]">[% c.maketext("stats.table-heading.team-matches-played") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-won.full") %]">[% c.maketext("stats.table-heading.matches-won") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-drawn.full") %]">[% c.maketext("stats.table-heading.matches-drawn") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-lost.full") %]">[% c.maketext("stats.table-heading.matches-lost") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]">[% c.maketext("stats.table-heading.for") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]">[% c.maketext("stats.table-heading.against") %]</th>
+[%
+IF match_template.handicapped;
+-%]
+            <th class="numeric"><span title="[% c.maketext("stats.table-heading.handicap.full") %]">[% c.maketext("stats.table-heading.handicap") %]</span></th>
+[%
+END;
+-%]
+            <th class="numeric" title="[% c.maketext("stats.table-heading."_ winner_type _ "-difference.full") %]">[% c.maketext("stats.table-heading."_ winner_type _"-difference") %]</th>
+[%
+IF ranking_template.assign_points;
+-%]
+            <th class="numeric">[% c.maketext("stats.table-heading.points") %]</th>
+[%
+END;
+-%]
+          </tr>
+        </thead>
+        <tbody>
+[%
+FOREACH entrant = auto_qualifiers;
+-%]
+                <tr>
+                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.group") %]">[% entrant.tournament_group.name %]</td>
+                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.group-pos") %]">[% entrant.group_position %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.team") %]">[% entrant.object_name | html_entity %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.team-matches-played.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_played) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.matches-won.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_won) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.matches-drawn.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_drawn) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.matches-lost") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_lost) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]" class="numeric">[% c.i18n_numberformat.format_number(for) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]" class="numeric">[% c.i18n_numberformat.format_number(against) %]</td>
+[%
+IF match_template.handicapped;
+-%]
+                  <td data-label="[% c.maketext("stats.table-heading.handicap.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.total_handicap) %]</td>
+[%
+END;
+-%]
+                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-difference.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.points_difference) %]</td>
+[%
+IF ranking_template.assign_points;
+-%]
+                  <td data-label="[% c.maketext("stats.table-heading.points") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.table_points) %]</td>
+[%
+END;
+-%]
+                </tr>
+[%
+END;
+-%]
+        </tbody>
+      </table>
+    </div><!-- .table-layout -->
+  </div><!-- .table-wrap -->
+</fieldset>
+<fieldset>
+  <legend>[% c.maketext("events.legend.tournament.round.selec-entrants.manual") %]</legend>
+  <div class="table-wrap">
+    <div class="table-layout table-layout-centre">
+      <table class="stripe hover row-border" id="non-auto-table">
+        <thead>
+          <tr>
+            <th>[% c.maketext("events.tournament.rounds.entrants.select") %]</th>
+            <th>[% c.maketext("events.tournament.rounds.entrants.group") %]</th>
+            <th>[% c.maketext("events.tournament.rounds.entrants.group-pos") %]</th>
+            <th>[% c.maketext("stats.table-heading.team") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading.team-matches-played.full") %]">[% c.maketext("stats.table-heading.team-matches-played") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-won.full") %]">[% c.maketext("stats.table-heading.matches-won") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-drawn.full") %]">[% c.maketext("stats.table-heading.matches-drawn") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-lost.full") %]">[% c.maketext("stats.table-heading.matches-lost") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]">[% c.maketext("stats.table-heading.for") %]</th>
+            <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]">[% c.maketext("stats.table-heading.against") %]</th>
+[%
+IF match_template.handicapped;
+-%]
+            <th class="numeric"><span title="[% c.maketext("stats.table-heading.handicap.full") %]">[% c.maketext("stats.table-heading.handicap") %]</span></th>
+[%
+END;
+-%]
+            <th class="numeric" title="[% c.maketext("stats.table-heading."_ winner_type _ "-difference.full") %]">[% c.maketext("stats.table-heading."_ winner_type _"-difference") %]</th>
+[%
+IF ranking_template.assign_points;
+-%]
+            <th class="numeric">[% c.maketext("stats.table-heading.points") %]</th>
+[%
+END;
+-%]
+          </tr>
+        </thead>
+        <tbody>
+[%
+FOREACH entrant = non_auto_qualifiers;
+-%]
+                <tr>
+                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.select") %]"><input type="checkbox" name="select-[% entrant.id %]" id="select-[% entrant.id %]" value="1" /></td>
+                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.group") %]">[% entrant.tournament_group.name %]</td>
+                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.group-pos") %]">[% entrant.group_position %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.team") %]">[% entrant.object_name | html_entity %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.team-matches-played.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_played) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.matches-won.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_won) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.matches-drawn.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_drawn) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading.matches-lost") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_lost) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]" class="numeric">[% c.i18n_numberformat.format_number(for) %]</td>
+                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]" class="numeric">[% c.i18n_numberformat.format_number(against) %]</td>
+[%
+IF match_template.handicapped;
+-%]
+                  <td data-label="[% c.maketext("stats.table-heading.handicap.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.total_handicap) %]</td>
+[%
+END;
+-%]
+                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-difference.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.points_difference) %]</td>
+[%
+IF ranking_template.assign_points;
+-%]
+                  <td data-label="[% c.maketext("stats.table-heading.points") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.table_points) %]</td>
+[%
+END;
+-%]
+                </tr>
+[%
+END;
+-%]
+        </tbody>
+      </table>
+    </div><!-- .table-layout -->
+  </div><!-- .table-wrap -->
+</fieldset>
+<input type="submit" name="Submit" value="[% c.maketext("form.button.save") %]" />
+</form>


### PR DESCRIPTION
- **[Fix]** Match cancellation now correctly sets points differences for matches where the winner is based on points won.
- **[New]** Table order attributes for tournament group tables moved to its own sub that returns the value to pass to order_by.
- **[New]** New TournamentRound[type] result methods to return the group position if it's a group round.
- **[New]** Select entrants template and JS files ready for that routine.