### PR TITLE
Add round entrants

### DIFF
--- a/lib/TopTable/Schema/Result/TeamMatch.pm
+++ b/lib/TopTable/Schema/Result/TeamMatch.pm
@@ -3535,6 +3535,23 @@ sub _can_update_score {
     $allowed = 0;
     $reason = $lang->maketext("matches.update.error.score-overridden");
     $level = "error";
+  } elsif ( defined($self->tournament_round) ) {
+    # If it's a tournament match, we can't update if we have entrants in the next round
+    my $round = $self->tournament_round;
+    my $next_round = $round->next_round;
+    
+    if ( defined($next_round) ) {
+      # There's a round that follows this one, so make sure we have the round number
+      if ( $next_round->has_matches ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-matches-created", $round->name);
+        $level = "error";
+      } elsif ( $next_round->has_entrants ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-entry-list-complete", $round->name);
+        $level = "error";
+      }
+    }
   }
   
   return (allowed => $allowed, reason => $reason, level => $level);
@@ -3558,6 +3575,23 @@ sub _can_delete_score {
     $allowed = 0;
     $reason = $lang->maketext("matches.update.delete.error.score-overridden");
     $level = "error";
+  } elsif ( defined($self->tournament_round) ) {
+    # If it's a tournament match, we can't update if we have entrants in the next round
+    my $round = $self->tournament_round;
+    my $next_round = $round->next_round;
+    
+    if ( defined($next_round) ) {
+      # There's a round that follows this one, so make sure we have the round number
+      if ( $next_round->has_matches ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-matches-created", $round->name);
+        $level = "error";
+      } elsif ( $next_round->has_entrants ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-entry-list-complete", $round->name);
+        $level = "error";
+      }
+    }
   }
   
   return (allowed => $allowed, reason => $reason, level => $level);
@@ -3581,6 +3615,23 @@ sub _can_cancel_match {
     $allowed = 0;
     $reason = $lang->maketext("matches.cancel.error.started");
     $level = "error";
+  } elsif ( defined($self->tournament_round) ) {
+    # If it's a tournament match, we can't update if we have entrants in the next round
+    my $round = $self->tournament_round;
+    my $next_round = $round->next_round;
+    
+    if ( defined($next_round) ) {
+      # There's a round that follows this one, so make sure we have the round number
+      if ( $next_round->has_matches ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-matches-created", $round->name);
+        $level = "error";
+      } elsif ( $next_round->has_entrants ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-entry-list-complete", $round->name);
+        $level = "error";
+      }
+    }
   }
   
   return (allowed => $allowed, reason => $reason, level => $level);
@@ -3604,6 +3655,23 @@ sub _can_uncancel_match {
     $allowed = 0;
     $reason = $lang->maketext("matches.uncancel.error.not-cancelled");
     $level = "error";
+  } elsif ( defined($self->tournament_round) ) {
+    # If it's a tournament match, we can't update if we have entrants in the next round
+    my $round = $self->tournament_round;
+    my $next_round = $round->next_round;
+    
+    if ( defined($next_round) ) {
+      # There's a round that follows this one, so make sure we have the round number
+      if ( $next_round->has_matches ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-matches-created", $round->name);
+        $level = "error";
+      } elsif ( $next_round->has_entrants ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-entry-list-complete", $round->name);
+        $level = "error";
+      }
+    }
   }
   
   return (allowed => $allowed, reason => $reason, level => $level);
@@ -3634,6 +3702,23 @@ sub _can_update_override {
     $allowed = 0;
     $reason = $lang->maketext("matches.override-score.error.match-not-complete");
     $level = "error";
+  } elsif ( defined($self->tournament_round) ) {
+    # If it's a tournament match, we can't update if we have entrants in the next round
+    my $round = $self->tournament_round;
+    my $next_round = $round->next_round;
+    
+    if ( defined($next_round) ) {
+      # There's a round that follows this one, so make sure we have the round number
+      if ( $next_round->has_matches ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-matches-created", $round->name);
+        $level = "error";
+      } elsif ( $next_round->has_entrants ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-entry-list-complete", $round->name);
+        $level = "error";
+      }
+    }
   }
   
   return (allowed => $allowed, reason => $reason, level => $level);
@@ -3660,6 +3745,23 @@ sub _can_postpone_match {
     $allowed = 0;
     $reason = $lang->maketext("matches.postpone-match.error.match-cancelled");
     $level = "error";
+  } elsif ( defined($self->tournament_round) ) {
+    # If it's a tournament match, we can't update if we have entrants in the next round
+    my $round = $self->tournament_round;
+    my $next_round = $round->next_round;
+    
+    if ( defined($next_round) ) {
+      # There's a round that follows this one, so make sure we have the round number
+      if ( $next_round->has_matches ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-matches-created", $round->name);
+        $level = "error";
+      } elsif ( $next_round->has_entrants ) {
+        $allowed = 0;
+        $reason = $lang->maketext("matches.update.error.next-round-entry-list-complete", $round->name);
+        $level = "error";
+      }
+    }
   }
   
   return (allowed => $allowed, reason => $reason, level => $level);

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -3022,6 +3022,12 @@ msgstr "Unable to update the score for this handicapped match before the handica
 msgid "matches.update.error.score-overridden"
 msgstr "The score for this match has been overridden, so the score can't be updated.  Delete the score override before updating."
 
+msgid "matches.update.error.next-round-matches-created"
+msgstr "The round following the one that this match is in already has its matches set, so scores in %1 cannot be altered."
+
+msgid "matches.update.error.next-round-entry-list-complete"
+msgstr "The entry list for the round following the one that this match is in already is already set, so scores in %1 cannot be altered."
+
 msgid "matches.update.delete.error.score-overridden"
 msgstr "You cannot delete scores in a match that&#39;s had the score overridden; delete the score override before deleting scores."
 
@@ -4181,11 +4187,32 @@ msgstr "Venue"
 msgid "events.tournaments.rounds.venue-use-home-team"
 msgstr "Home team&#39;s venue"
 
-msgid "events.legend.tournament.round.selec-entrants.auto"
+msgid "events.tournaments.rounds.entry-list-team"
+msgstr "Team list"
+
+msgid "events.tournaments.rounds.entry-list.col-header-team"
+msgstr "Team"
+
+msgid "events.tournaments.rounds.entry-list-singles"
+msgstr "Player list"
+
+msgid "events.tournaments.rounds.entry-list.col-header-team"
+msgstr "Player"
+
+msgid "events.tournaments.rounds.entry-list-doubles"
+msgstr "Player list"
+
+msgid "events.tournaments.rounds.entry-list.col-header-team"
+msgstr "Pair"
+
+msgid "events.legend.tournament.round.select-entrants"
+msgstr "Qualifiers"
+
+msgid "events.legend.tournament.round.select-entrants.auto"
 msgstr "Automatic qualifiers (you cannot change these)"
 
-msgid "events.legend.tournament.round.selec-entrants.manual"
-msgstr "Best runners up (select these from the list)"
+msgid "events.legend.tournament.round.select-entrants.manual"
+msgstr "Best runners up (select %1 from the list using the checkboxes)"
 
 msgid "events.tournament.rounds.entrants.group"
 msgstr "Group"
@@ -4193,8 +4220,20 @@ msgstr "Group"
 msgid "events.tournament.rounds.entrants.select"
 msgstr "Selection"
 
+msgid "events.tournament.rounds.entrants.select-id"
+msgstr "Selection ID"
+
 msgid "events.tournament.rounds.entrants.group-pos"
 msgstr "Group position"
+
+msgid "events.tournament.rounds.select-entrants.in-auto-qualifiers"
+msgstr "%1 of the submitted teams are in the auto-qualifiers list, so cannot be manually selected."
+
+msgid "events.tournament.rounds.select-entrants.invalid-entries"
+msgstr "Some of the submitted teams are invalid."
+
+msgid "events.tournament.rounds.select-entrants.wrong-number-of-entrants-selected"
+msgstr "%1 entrants for the round were selected; %2 must be selected."
 
 ### Reports
 msgid "reports.name.loan-players"
@@ -6720,10 +6759,16 @@ msgid "tournaments.rounds.field.round-of"
 msgstr "Number of entrants"
 
 msgid "events.tournaments.rounds.entrants.update.error.round-already-has-entrants"
-msgstr "The entrants for %1 have already been selected."
+msgstr "The entrants for the %1 have already been selected."
 
 msgid "events.tournaments.rounds.entrants.update.error.group-round"
 msgstr "%1 is a group round, so entrants are selected by adding groups."
+
+msgid "events.tournaments.rounds.entrants.update.add-manual.error.not-first-ko-round"
+msgstr "Manual entrants can only be selected for the first knock-out round of a tournament."
+
+msgid "events.tournaments.rounds.entrants.update.add-manual.error.auto-fills-all-spaces"
+msgstr "Automatic qualifiers from the previous round fill all spaces in this one."
 
 msgid "events.tournaments.rounds.entrants.update.error.prev-round-incomplete"
 msgstr "Entrants can only be selected once the previous round is complete."
@@ -7293,6 +7338,12 @@ msgstr "Edited %1%2."
 
 msgid "system-event-log.description.delete-group"
 msgstr "Deleted %1%2."
+
+msgid "system-event-log.description.create-round-entrants"
+msgstr "Created the entry list for %1%2."
+
+msgid "system-event-log.description.delete-round-entrants"
+msgstr "Removed the entry list for %1%2."
 
 msgid "system-event-log.and"
 msgstr "and"

--- a/root/static/script/events/tournaments/rounds/select-entrants-points-hcp.js
+++ b/root/static/script/events/tournaments/rounds/select-entrants-points-hcp.js
@@ -15,27 +15,27 @@ $(document).ready(function() {
     ordering: false,
     columnDefs: [{
       // Group
-      responsivePriority: 11,
+      responsivePriority: 13,
       targets: 0
     }, {
       // Group position
-      responsivePriority: 2,
+      responsivePriority: 3,
       targets: 1
     }, {
       // Entrant (team / player / pair)
-      responsivePriority: 1,
+      responsivePriority: 2,
       targets: 2
     }, {
       // Matches played
-      responsivePriority: 8,
+      responsivePriority: 10,
       targets: 3
     }, {
       // Won
-      responsivePriority: 7,
+      responsivePriority: 8,
       targets: 4
     }, {
       // Drawn
-      responsivePriority: 10,
+      responsivePriority: 11,
       targets: 5
     }, {
       // Lost
@@ -43,11 +43,11 @@ $(document).ready(function() {
       targets: 6
     }, {
       // For
-      responsivePriority: 5,
+      responsivePriority: 6,
       targets: 7
     }, {
       // Against
-      responsivePriority: 6,
+      responsivePriority: 7,
       targets: 8
     }, {
       // Handicap
@@ -55,16 +55,16 @@ $(document).ready(function() {
       targets: 9
     }, {
       // Points / games difference
-      responsivePriority: 4,
+      responsivePriority: 5,
       targets: 10
     }, {
       // Points
-      responsivePriority: 3,
+      responsivePriority: 4,
       targets: 11
     }]
   });
   
-  $("#non-auto-table").DataTable({
+  let select_tb = $("#non-auto-table").DataTable({
     responsive: true,
     paging: true,
     pageLength: -1,
@@ -75,54 +75,75 @@ $(document).ready(function() {
     searching: true,
     ordering: false,
     columnDefs: [{
-      // Group
-      responsivePriority: 11,
+      // Selection ID (hidden)
+      visible: 0,
       targets: 0
     }, {
-      // Group position
-      responsivePriority: 2,
+      // Section checkbox
+      responsivePriority: 1,
       targets: 1
     }, {
-      // Entrant (team / player / pair)
-      responsivePriority: 1,
+      // Group
+      responsivePriority: 13,
       targets: 2
     }, {
-      // Matches played
-      responsivePriority: 8,
+      // Group position
+      responsivePriority: 3,
       targets: 3
     }, {
-      // Won
-      responsivePriority: 7,
+      // Entrant (team / player / pair)
+      responsivePriority: 2,
       targets: 4
     }, {
-      // Drawn
+      // Matches played
       responsivePriority: 10,
       targets: 5
     }, {
-      // Lost
-      responsivePriority: 9,
+      // Won
+      responsivePriority: 8,
       targets: 6
     }, {
-      // For
-      responsivePriority: 5,
+      // Drawn
+      responsivePriority: 11,
       targets: 7
     }, {
-      // Against
-      responsivePriority: 6,
+      // Lost
+      responsivePriority: 9,
       targets: 8
+    }, {
+      // For
+      responsivePriority: 6,
+      targets: 9
+    }, {
+      // Against
+      responsivePriority: 7,
+      targets: 10
     }, {
       // Handicap
       responsivePriority: 12,
-      targets: 9
+      targets: 11
     }, {
       // Points / games difference
-      responsivePriority: 4,
-      targets: 10
+      responsivePriority: 5,
+      targets: 12
     }, {
       // Points
-      responsivePriority: 3,
-      targets: 11
+      responsivePriority: 4,
+      targets: 13
     }]
+  });
+  
+  select_tb.on("click", "tbody tr", function(event) {
+    let ent_id = select_tb.row(this).data()[0];
+    
+    if ( event.target.localName !== "a" ) {
+      // Toggle checked property
+      if ( $("#select-" + ent_id).prop("checked") ) {
+        $("#select-" + ent_id).prettyCheckable("uncheck");
+      } else {
+        $("#select-" + ent_id).prettyCheckable("check");
+      }
+    }
   });
   
   $("select[name=auto-table_length], select[name=non-auto-table_length]").chosen({
@@ -131,4 +152,6 @@ $(document).ready(function() {
     allow_single_deselect: true,
     width: "75px"
   });
+  
+  $("#accordion").accordion({heightStyle: "content"});
 });

--- a/root/static/script/events/tournaments/rounds/select-entrants-points.js
+++ b/root/static/script/events/tournaments/rounds/select-entrants-points.js
@@ -15,27 +15,27 @@ $(document).ready(function() {
     ordering: false,
     columnDefs: [{
       // Group
-      responsivePriority: 11,
+      responsivePriority: 12,
       targets: 0
     }, {
       // Group position
-      responsivePriority: 2,
+      responsivePriority: 3,
       targets: 1
     }, {
       // Entrant (team / player / pair)
-      responsivePriority: 1,
+      responsivePriority: 2,
       targets: 2
     }, {
       // Matches played
-      responsivePriority: 8,
+      responsivePriority: 10,
       targets: 3
     }, {
       // Won
-      responsivePriority: 7,
+      responsivePriority: 8,
       targets: 4
     }, {
       // Drawn
-      responsivePriority: 10,
+      responsivePriority: 11,
       targets: 5
     }, {
       // Lost
@@ -43,24 +43,24 @@ $(document).ready(function() {
       targets: 6
     }, {
       // For
-      responsivePriority: 5,
+      responsivePriority: 6,
       targets: 7
     }, {
       // Against
-      responsivePriority: 6,
+      responsivePriority: 7,
       targets: 8
     }, {
       // Points / games difference
-      responsivePriority: 4,
+      responsivePriority: 5,
       targets: 9
     }, {
       // Points
-      responsivePriority: 3,
+      responsivePriority: 4,
       targets: 10
     }]
   });
   
-  $("#non-auto-table").DataTable({
+  let select_tb = $("#non-auto-table").DataTable({
     responsive: true,
     paging: true,
     pageLength: -1,
@@ -71,50 +71,71 @@ $(document).ready(function() {
     searching: true,
     ordering: false,
     columnDefs: [{
-      // Group
-      responsivePriority: 11,
+      // Selection ID (hidden)
+      visible: 0,
       targets: 0
     }, {
-      // Group position
-      responsivePriority: 2,
+      // Section checkbox
+      responsivePriority: 1,
       targets: 1
     }, {
-      // Entrant (team / player / pair)
-      responsivePriority: 1,
+      // Group
+      responsivePriority: 12,
       targets: 2
     }, {
-      // Matches played
-      responsivePriority: 8,
+      // Group position
+      responsivePriority: 3,
       targets: 3
     }, {
-      // Won
-      responsivePriority: 7,
+      // Entrant (team / player / pair)
+      responsivePriority: 2,
       targets: 4
     }, {
-      // Drawn
+      // Matches played
       responsivePriority: 10,
       targets: 5
     }, {
-      // Lost
-      responsivePriority: 9,
+      // Won
+      responsivePriority: 8,
       targets: 6
     }, {
-      // For
-      responsivePriority: 5,
+      // Drawn
+      responsivePriority: 11,
       targets: 7
     }, {
-      // Against
-      responsivePriority: 6,
+      // Lost
+      responsivePriority: 9,
       targets: 8
     }, {
-      // Points / games difference
-      responsivePriority: 4,
+      // For
+      responsivePriority: 6,
       targets: 9
     }, {
-      // Points
-      responsivePriority: 3,
+      // Against
+      responsivePriority: 7,
       targets: 10
+    }, {
+      // Points / games difference
+      responsivePriority: 5,
+      targets: 12
+    }, {
+      // Points
+      responsivePriority: 4,
+      targets: 13
     }]
+  });
+  
+  select_tb.on("click", "tbody tr", function(event) {
+    let ent_id = select_tb.row(this).data()[0];
+    
+    if ( event.target.localName !== "a" ) {
+      // Toggle checked property
+      if ( $("#select-" + ent_id).prop("checked") ) {
+        $("#select-" + ent_id).prettyCheckable("uncheck");
+      } else {
+        $("#select-" + ent_id).prettyCheckable("check");
+      }
+    }
   });
   
   $("select[name=auto-table_length], select[name=non-auto-table_length]").chosen({
@@ -123,4 +144,6 @@ $(document).ready(function() {
     allow_single_deselect: true,
     width: "75px"
   });
+  
+  $("#accordion").accordion({heightStyle: "content"});
 });

--- a/root/static/script/events/tournaments/rounds/select-entrants.js
+++ b/root/static/script/events/tournaments/rounds/select-entrants.js
@@ -19,11 +19,11 @@ $(document).ready(function() {
       targets: 0
     }, {
       // Group position
-      responsivePriority: 2,
+      responsivePriority: 3,
       targets: 1
     }, {
       // Entrant (team / player / pair)
-      responsivePriority: 1,
+      responsivePriority: 2,
       targets: 2
     }, {
       // Matches played
@@ -31,32 +31,32 @@ $(document).ready(function() {
       targets: 3
     }, {
       // Won
-      responsivePriority: 6,
+      responsivePriority: 7,
       targets: 4
     }, {
       // Drawn
-      responsivePriority: 8,
+      responsivePriority: 10,
       targets: 5
     }, {
       // Lost
-      responsivePriority: 7,
+      responsivePriority: 8,
       targets: 6
     }, {
       // For
-      responsivePriority: 4,
+      responsivePriority: 5,
       targets: 7
     }, {
       // Against
-      responsivePriority: 5,
+      responsivePriority: 6,
       targets: 8
     }, {
       // Points / games difference
-      responsivePriority: 3,
+      responsivePriority: 4,
       targets: 9
     }]
   });
   
-  $("#non-auto-table").DataTable({
+  let select_tb = $("#non-auto-table").DataTable({
     responsive: true,
     paging: true,
     pageLength: -1,
@@ -67,46 +67,67 @@ $(document).ready(function() {
     searching: true,
     ordering: false,
     columnDefs: [{
-      // Group
-      responsivePriority: 11,
+      // Selection ID (hidden)
+      visible: 0,
       targets: 0
     }, {
-      // Group position
-      responsivePriority: 2,
+      // Section checkbox
+      responsivePriority: 1,
       targets: 1
     }, {
-      // Entrant (team / player / pair)
-      responsivePriority: 1,
+      // Group
+      responsivePriority: 11,
       targets: 2
+    }, {
+      // Group position
+      responsivePriority: 3,
+      targets: 3
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 2,
+      targets: 4
     }, {
       // Matches played
       responsivePriority: 9,
-      targets: 3
-    }, {
-      // Won
-      responsivePriority: 6,
-      targets: 4
-    }, {
-      // Drawn
-      responsivePriority: 8,
       targets: 5
     }, {
-      // Lost
+      // Won
       responsivePriority: 7,
       targets: 6
     }, {
-      // For
-      responsivePriority: 4,
+      // Drawn
+      responsivePriority: 10,
       targets: 7
     }, {
-      // Against
-      responsivePriority: 5,
+      // Lost
+      responsivePriority: 8,
       targets: 8
     }, {
-      // Points / games difference
-      responsivePriority: 3,
+      // For
+      responsivePriority: 5,
       targets: 9
+    }, {
+      // Against
+      responsivePriority: 6,
+      targets: 10
+    }, {
+      // Points / games difference
+      responsivePriority: 4,
+      targets: 11
     }]
+  });
+  
+  select_tb.on("click", "tbody tr", function(event) {
+    let ent_id = select_tb.row(this).data()[0];
+    
+    if ( event.target.localName !== "a" ) {
+      // Toggle checked property
+      if ( $("#select-" + ent_id).prop("checked") ) {
+        $("#select-" + ent_id).prettyCheckable("uncheck");
+      } else {
+        $("#select-" + ent_id).prettyCheckable("check");
+      }
+    }
   });
   
   $("select[name=auto-table_length], select[name=non-auto-table_length]").chosen({
@@ -115,4 +136,6 @@ $(document).ready(function() {
     allow_single_deselect: true,
     width: "75px"
   });
+  
+  $("#accordion").accordion({heightStyle: "content"});
 });

--- a/root/static/script/events/tournaments/rounds/view.js
+++ b/root/static/script/events/tournaments/rounds/view.js
@@ -58,6 +58,25 @@ $(document).ready(function() {
     width: "75px"
   });
   
+  let entrants_table = $("#entrants").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: 25,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+  });
+  
+  $("select[name=entrants_length]").chosen({
+    disable_search: true,
+    single_backstroke_delete: false,
+    allow_single_deselect: true,
+    width: "75px"
+  });
+  
   /*
     Responsive tabs
   */
@@ -68,6 +87,8 @@ $(document).ready(function() {
       if (tab.selector == "#matches") {
         // Redraw the adjustments table
         matches_table.responsive.recalc();
+      } else if (tab.selector == "#summary") {
+        entrants_table.responsive.recalc();
       }
     }
   });

--- a/root/templates/html/events/tournaments/rounds/select-entrants.ttkt
+++ b/root/templates/html/events/tournaments/rounds/select-entrants.ttkt
@@ -1,147 +1,209 @@
-<form action="[% form_action %]">
+[%
+USE scalar;
+%]
+<form method="post" action="[% form_action %]">
 <fieldset>
-  <legend>[% c.maketext("events.legend.tournament.round.selec-entrants.auto") %]</legend>
-  <div class="table-wrap">
-    <div class="table-layout table-layout-centre">
-      <table class="stripe hover row-border" id="auto-table">
-        <thead>
-          <tr>
-            <th>[% c.maketext("events.tournament.rounds.entrants.group") %]</th>
-            <th>[% c.maketext("events.tournament.rounds.entrants.group-pos") %]</th>
-            <th>[% c.maketext("stats.table-heading.team") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading.team-matches-played.full") %]">[% c.maketext("stats.table-heading.team-matches-played") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-won.full") %]">[% c.maketext("stats.table-heading.matches-won") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-drawn.full") %]">[% c.maketext("stats.table-heading.matches-drawn") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-lost.full") %]">[% c.maketext("stats.table-heading.matches-lost") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]">[% c.maketext("stats.table-heading.for") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]">[% c.maketext("stats.table-heading.against") %]</th>
+  <legend>[% c.maketext("events.legend.tournament.round.select-entrants") %]</legend>
 [%
-IF match_template.handicapped;
+# If we can add manual AND we have auto qualifiers (i.e., a previous round), show the accordion div
+SET can_update_manual = round.scalar.can_update("manual-entrants");
+SET round_number = round.round_number;
+IF round_number > 1 AND can_update_manual;
+  SET accordion = 1;
+ELSE;
+  SET accordion = 0;
+END;
+
+IF accordion;
 -%]
-            <th class="numeric"><span title="[% c.maketext("stats.table-heading.handicap.full") %]">[% c.maketext("stats.table-heading.handicap") %]</span></th>
+  <div id="accordion">
+[%
+END;
+
+IF round_number > 1;
+  # We only get auto entrants if we're passed round 1
+-%]
+    <h3>[% c.maketext("events.legend.tournament.round.select-entrants.auto") %]</h3>
+    <div>
+      <div class="table-wrap">
+        <div class="table-layout table-layout-centre">
+          <table class="stripe hover row-border" id="auto-table">
+            <thead>
+              <tr>
+                <th>[% c.maketext("events.tournament.rounds.entrants.group") %]</th>
+                <th>[% c.maketext("events.tournament.rounds.entrants.group-pos") %]</th>
+                <th>[% c.maketext("stats.table-heading.team") %]</th>
+                <th class="numeric" title="[% c.maketext("stats.table-heading.team-matches-played.full") %]">[% c.maketext("stats.table-heading.team-matches-played") %]</th>
+                <th class="numeric" title="[% c.maketext("stats.table-heading.matches-won.full") %]">[% c.maketext("stats.table-heading.matches-won") %]</th>
+                <th class="numeric" title="[% c.maketext("stats.table-heading.matches-drawn.full") %]">[% c.maketext("stats.table-heading.matches-drawn") %]</th>
+                <th class="numeric" title="[% c.maketext("stats.table-heading.matches-lost.full") %]">[% c.maketext("stats.table-heading.matches-lost") %]</th>
+                <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]">[% c.maketext("stats.table-heading.for") %]</th>
+                <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]">[% c.maketext("stats.table-heading.against") %]</th>
+[%
+  IF match_template.handicapped;
+-%]
+                <th class="numeric"><span title="[% c.maketext("stats.table-heading.handicap.full") %]">[% c.maketext("stats.table-heading.handicap") %]</span></th>
+[%
+  END;
+-%]
+                <th class="numeric" title="[% c.maketext("stats.table-heading."_ winner_type _ "-difference.full") %]">[% c.maketext("stats.table-heading."_ winner_type _"-difference") %]</th>
+[%
+  IF ranking_template.assign_points;
+-%]
+                <th class="numeric">[% c.maketext("stats.table-heading.points") %]</th>
+[%
+  END;
+-%]
+              </tr>
+            </thead>
+            <tbody>
+[%
+  FOREACH entrant = auto_qualifiers;
+    IF winner_type == "games";
+      SET for = entrant.games_won;
+      SET against = entrant.games_lost;
+      SET diff = entrant.games_difference;
+    ELSE;
+      SET for = entrant.points_won;
+      SET against = entrant.points_lost;
+      SET diff = entrant.points_difference;
+    END;
+-%]
+                    <tr>
+                      <td data-label="[% c.maketext("events.tournament.rounds.entrants.group") %]">[% entrant.tournament_group.name %]</td>
+                      <td data-label="[% c.maketext("events.tournament.rounds.entrants.group-pos") %]">[% entrant.group_position %]</td>
+                      <td data-label="[% c.maketext("stats.table-heading.team") %]">[% entrant.object_name | html_entity %]</td>
+                      <td data-label="[% c.maketext("stats.table-heading.team-matches-played.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_played) %]</td>
+                      <td data-label="[% c.maketext("stats.table-heading.matches-won.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_won) %]</td>
+                      <td data-label="[% c.maketext("stats.table-heading.matches-drawn.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_drawn) %]</td>
+                      <td data-label="[% c.maketext("stats.table-heading.matches-lost") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_lost) %]</td>
+                      <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]" class="numeric">[% c.i18n_numberformat.format_number(for) %]</td>
+                      <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]" class="numeric">[% c.i18n_numberformat.format_number(against) %]</td>
+[%
+    IF match_template.handicapped;
+-%]
+                      <td data-label="[% c.maketext("stats.table-heading.handicap.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.total_handicap) %]</td>
+[%
+    END;
+-%]
+                      <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-difference.full") %]" class="numeric">[% c.i18n_numberformat.format_number(diff) %]</td>
+[%
+    IF ranking_template.assign_points;
+-%]
+                      <td data-label="[% c.maketext("stats.table-heading.points") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.table_points) %]</td>
+[%
+    END;
+-%]
+                    </tr>
+[%
+  END;
+-%]
+          </tbody>
+        </table>
+      </div><!-- .table-layout -->
+    </div><!-- .table-wrap -->
+  </div><!-- accordion div -->
+[%
+END;
+
+IF can_update_manual;
+  # Show manual entrants div if we can update manual entrants
+  # Number we can select is the round_of figure minus the number of automatic qualifiers
+  SET manual_num = round.round_of - prev_round.num_qualifiers;
+-%]
+  <h3>[% c.maketext("events.legend.tournament.round.select-entrants.manual", manual_num) %]</h3>
+  <div>
+    <div class="table-wrap">
+      <div class="table-layout table-layout-centre">
+        <table class="stripe hover row-border" id="non-auto-table">
+          <thead>
+            <tr>
+              <th>[% c.maketext("events.tournament.rounds.entrants.select-id") %]</th>
+              <th>[% c.maketext("events.tournament.rounds.entrants.select") %]</th>
+              <th>[% c.maketext("events.tournament.rounds.entrants.group") %]</th>
+              <th>[% c.maketext("events.tournament.rounds.entrants.group-pos") %]</th>
+              <th>[% c.maketext("stats.table-heading.team") %]</th>
+              <th class="numeric" title="[% c.maketext("stats.table-heading.team-matches-played.full") %]">[% c.maketext("stats.table-heading.team-matches-played") %]</th>
+              <th class="numeric" title="[% c.maketext("stats.table-heading.matches-won.full") %]">[% c.maketext("stats.table-heading.matches-won") %]</th>
+              <th class="numeric" title="[% c.maketext("stats.table-heading.matches-drawn.full") %]">[% c.maketext("stats.table-heading.matches-drawn") %]</th>
+              <th class="numeric" title="[% c.maketext("stats.table-heading.matches-lost.full") %]">[% c.maketext("stats.table-heading.matches-lost") %]</th>
+              <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]">[% c.maketext("stats.table-heading.for") %]</th>
+              <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]">[% c.maketext("stats.table-heading.against") %]</th>
+[%
+  IF match_template.handicapped;
+-%]
+              <th class="numeric"><span title="[% c.maketext("stats.table-heading.handicap.full") %]">[% c.maketext("stats.table-heading.handicap") %]</span></th>
+[%
+  END;
+-%]
+              <th class="numeric" title="[% c.maketext("stats.table-heading."_ winner_type _ "-difference.full") %]">[% c.maketext("stats.table-heading."_ winner_type _"-difference") %]</th>
+[%
+  IF ranking_template.assign_points;
+-%]
+              <th class="numeric">[% c.maketext("stats.table-heading.points") %]</th>
+[%
+  END;
+-%]
+            </tr>
+          </thead>
+          <tbody>
+[%
+  FOREACH entrant = non_auto_qualifiers;
+    IF winner_type == "games";
+      SET for = entrant.games_won;
+      SET against = entrant.games_lost;
+      SET diff = entrant.games_difference;
+    ELSE;
+      SET for = entrant.points_won;
+      SET against = entrant.points_lost;
+      SET diff = entrant.points_difference;
+    END;
+-%]
+                  <tr>
+                    <td data-label="[% c.maketext("events.tournament.rounds.entrants.select-id") %]">[% entrant.id %]</td>
+                    <td data-label="[% c.maketext("events.tournament.rounds.entrants.select") %]"><input type="checkbox" class="entrant-select" name="select-[% entrant.id %]" id="select-[% entrant.id %]" value="1" /></td>
+                    <td data-label="[% c.maketext("events.tournament.rounds.entrants.group") %]">[% entrant.tournament_group.name %]</td>
+                    <td data-label="[% c.maketext("events.tournament.rounds.entrants.group-pos") %]">[% entrant.group_position %]</td>
+                    <td data-label="[% c.maketext("stats.table-heading.team") %]">[% entrant.object_name | html_entity %]</td>
+                    <td data-label="[% c.maketext("stats.table-heading.team-matches-played.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_played) %]</td>
+                    <td data-label="[% c.maketext("stats.table-heading.matches-won.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_won) %]</td>
+                    <td data-label="[% c.maketext("stats.table-heading.matches-drawn.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_drawn) %]</td>
+                    <td data-label="[% c.maketext("stats.table-heading.matches-lost") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_lost) %]</td>
+                    <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]" class="numeric">[% c.i18n_numberformat.format_number(for) %]</td>
+                    <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]" class="numeric">[% c.i18n_numberformat.format_number(against) %]</td>
+[%
+    IF match_template.handicapped;
+-%]
+                    <td data-label="[% c.maketext("stats.table-heading.handicap.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.total_handicap) %]</td>
+[%
+    END;
+-%]
+                    <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-difference.full") %]" class="numeric">[% c.i18n_numberformat.format_number(diff) %]</td>
+[%
+    IF ranking_template.assign_points;
+-%]
+                    <td data-label="[% c.maketext("stats.table-heading.points") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.table_points) %]</td>
+[%
+    END;
+-%]
+                  </tr>
+[%
+  END;
+-%]
+          </tbody>
+        </table>
+      </div><!-- .table-layout -->
+    </div><!-- .table-wrap -->
+  </div><!-- accordion div -->
+[%
+END; # IF can_update_manual
+
+IF accordion;
+-%]
+</div>
 [%
 END;
 -%]
-            <th class="numeric" title="[% c.maketext("stats.table-heading."_ winner_type _ "-difference.full") %]">[% c.maketext("stats.table-heading."_ winner_type _"-difference") %]</th>
-[%
-IF ranking_template.assign_points;
--%]
-            <th class="numeric">[% c.maketext("stats.table-heading.points") %]</th>
-[%
-END;
--%]
-          </tr>
-        </thead>
-        <tbody>
-[%
-FOREACH entrant = auto_qualifiers;
--%]
-                <tr>
-                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.group") %]">[% entrant.tournament_group.name %]</td>
-                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.group-pos") %]">[% entrant.group_position %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.team") %]">[% entrant.object_name | html_entity %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.team-matches-played.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_played) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.matches-won.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_won) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.matches-drawn.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_drawn) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.matches-lost") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_lost) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]" class="numeric">[% c.i18n_numberformat.format_number(for) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]" class="numeric">[% c.i18n_numberformat.format_number(against) %]</td>
-[%
-IF match_template.handicapped;
--%]
-                  <td data-label="[% c.maketext("stats.table-heading.handicap.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.total_handicap) %]</td>
-[%
-END;
--%]
-                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-difference.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.points_difference) %]</td>
-[%
-IF ranking_template.assign_points;
--%]
-                  <td data-label="[% c.maketext("stats.table-heading.points") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.table_points) %]</td>
-[%
-END;
--%]
-                </tr>
-[%
-END;
--%]
-        </tbody>
-      </table>
-    </div><!-- .table-layout -->
-  </div><!-- .table-wrap -->
-</fieldset>
-<fieldset>
-  <legend>[% c.maketext("events.legend.tournament.round.selec-entrants.manual") %]</legend>
-  <div class="table-wrap">
-    <div class="table-layout table-layout-centre">
-      <table class="stripe hover row-border" id="non-auto-table">
-        <thead>
-          <tr>
-            <th>[% c.maketext("events.tournament.rounds.entrants.select") %]</th>
-            <th>[% c.maketext("events.tournament.rounds.entrants.group") %]</th>
-            <th>[% c.maketext("events.tournament.rounds.entrants.group-pos") %]</th>
-            <th>[% c.maketext("stats.table-heading.team") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading.team-matches-played.full") %]">[% c.maketext("stats.table-heading.team-matches-played") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-won.full") %]">[% c.maketext("stats.table-heading.matches-won") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-drawn.full") %]">[% c.maketext("stats.table-heading.matches-drawn") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading.matches-lost.full") %]">[% c.maketext("stats.table-heading.matches-lost") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]">[% c.maketext("stats.table-heading.for") %]</th>
-            <th class="numeric" title="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]">[% c.maketext("stats.table-heading.against") %]</th>
-[%
-IF match_template.handicapped;
--%]
-            <th class="numeric"><span title="[% c.maketext("stats.table-heading.handicap.full") %]">[% c.maketext("stats.table-heading.handicap") %]</span></th>
-[%
-END;
--%]
-            <th class="numeric" title="[% c.maketext("stats.table-heading."_ winner_type _ "-difference.full") %]">[% c.maketext("stats.table-heading."_ winner_type _"-difference") %]</th>
-[%
-IF ranking_template.assign_points;
--%]
-            <th class="numeric">[% c.maketext("stats.table-heading.points") %]</th>
-[%
-END;
--%]
-          </tr>
-        </thead>
-        <tbody>
-[%
-FOREACH entrant = non_auto_qualifiers;
--%]
-                <tr>
-                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.select") %]"><input type="checkbox" name="select-[% entrant.id %]" id="select-[% entrant.id %]" value="1" /></td>
-                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.group") %]">[% entrant.tournament_group.name %]</td>
-                  <td data-label="[% c.maketext("events.tournament.rounds.entrants.group-pos") %]">[% entrant.group_position %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.team") %]">[% entrant.object_name | html_entity %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.team-matches-played.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_played) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.matches-won.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_won) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.matches-drawn.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_drawn) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading.matches-lost") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_lost) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-for.full") %]" class="numeric">[% c.i18n_numberformat.format_number(for) %]</td>
-                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-against.full") %]" class="numeric">[% c.i18n_numberformat.format_number(against) %]</td>
-[%
-IF match_template.handicapped;
--%]
-                  <td data-label="[% c.maketext("stats.table-heading.handicap.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.total_handicap) %]</td>
-[%
-END;
--%]
-                  <td data-label="[% c.maketext("stats.table-heading." _ winner_type _ "-difference.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.points_difference) %]</td>
-[%
-IF ranking_template.assign_points;
--%]
-                  <td data-label="[% c.maketext("stats.table-heading.points") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.table_points) %]</td>
-[%
-END;
--%]
-                </tr>
-[%
-END;
--%]
-        </tbody>
-      </table>
-    </div><!-- .table-layout -->
-  </div><!-- .table-wrap -->
 </fieldset>
 <input type="submit" name="Submit" value="[% c.maketext("form.button.save") %]" />
 </form>

--- a/root/templates/html/events/tournaments/rounds/view.ttkt
+++ b/root/templates/html/events/tournaments/rounds/view.ttkt
@@ -44,6 +44,45 @@ END;
             <td>[% venue_text %]</td>
           </tr>
         </table>
+        
+[%
+IF entrants.count;
+-%]
+        <h4>[% c.maketext("events.tournaments.rounds.entry-list-" _ round.entry_type) %]</h4>
+        <table id="entrants" class="stripe hover row-border" width="100%">
+          <thead>
+            <tr>
+              <th>[% c.maketext("events.tournaments.rounds.entry-list.col-header-" _ round.entry_type) %]</th>
+            </tr>
+          </thead>
+          <tbody>
+[%
+  WHILE (entrant = entrants.next);
+    SWITCH round.entry_type;
+      CASE "team";
+        SET club = entrant.tournament_team.team_season.club_season.club;
+        SET team = entrant.tournament_team.team_season.team;
+        IF specific_season;
+          SET uri = c.uri_for_action("/events/teams_view_by_url_key_specific_season", [event.url_key, season.url_key, club.url_key, team.url_key]);
+        ELSE;
+          SET uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, club.url_key, team.url_key]);
+        END;
+      CASE "singles";
+      
+      CASE "doubles";
+    END;
+-%]
+            <tr>
+              <td><a href="[% uri %]">[% entrant.object_name | html_entity %]</a></td>
+            </tr>
+[%
+  END;
+-%]
+          </tbody>
+        </table>
+[%
+END;
+-%]
       </div><!-- .table-layout -->
     </div><!-- .table-wrap -->
   </div><!-- #summary -->

--- a/root/templates/html/matches/team/view.ttkt
+++ b/root/templates/html/matches/team/view.ttkt
@@ -397,7 +397,7 @@ END;
 IF is_tourn;
   # For tournaments, we put the team divisions in too
 -%]
-              <th class="numeric">[% c.maketext("matches.summaries.heading.division") %]</th>
+              <th>[% c.maketext("matches.summaries.heading.division") %]</th>
 [%
 END;
 IF match.handicapped;


### PR DESCRIPTION
- **[New]** Add the round's qualifying entrants from the previous round.  Includes a way to select entrants from the previous round (if it was a group round) that didn't automatically qualify.
- **[New]** Disable the ability to update or delete a match score, or set the handicap, or override the score if it's in a tournament and the next round has its entrants set, or has matches (you can't have matches without entrants of course, but the error is specific to which one is true, has matches overrides has entrants).
- **[New]** Check in can_update for TournamentRound for adding manual entrants (i.e., best runners up from the previous round, if it's a group round).
- **[New]** Entrant list on tournament round summary page, when the entrants have been set.
- **[Fix]** "League division" teams table column header was set as numeric incorrectly.