### PR TITLE
Knock-out round match creation (and deletion)

### DIFF
--- a/lib/TopTable/Schema/Result/FixturesGrid.pm
+++ b/lib/TopTable/Schema/Result/FixturesGrid.pm
@@ -993,6 +993,13 @@ sub create_matches {
       push(@{$response->{error}}, $lang->maketext("fixtures-grids.form.create-fixtures.error.grid-invalid"));
       $response->{can_complete} = 0;
     }
+    
+    my %can = $tourn_group->can_update("matches");
+    
+    if ( !$can{allowed} ) {
+      push(@{$response->{$can{level}}}, $can{reason});
+      return $response;
+    }
   }
   
   # If we have errors at the moment, just return straight away

--- a/lib/TopTable/Schema/Result/TeamMatch.pm
+++ b/lib/TopTable/Schema/Result/TeamMatch.pm
@@ -113,7 +113,7 @@ If NULL, this must be part of a tournament
   data_type: 'integer'
   extra: {unsigned => 1}
   is_foreign_key: 1
-  is_nullable: 0
+  is_nullable: 1
 
 =head2 played_date
 
@@ -421,7 +421,7 @@ __PACKAGE__->add_columns(
     data_type => "integer",
     extra => { unsigned => 1 },
     is_foreign_key => 1,
-    is_nullable => 0,
+    is_nullable => 1,
   },
   "played_date",
   { data_type => "date", datetime_undef_if_invalid => 1, is_nullable => 0 },
@@ -767,7 +767,12 @@ __PACKAGE__->belongs_to(
   "scheduled_week",
   "TopTable::Schema::Result::FixturesWeek",
   { id => "scheduled_week" },
-  { is_deferrable => 1, on_delete => "RESTRICT", on_update => "RESTRICT" },
+  {
+    is_deferrable => 1,
+    join_type     => "LEFT",
+    on_delete     => "RESTRICT",
+    on_update     => "RESTRICT",
+  },
 );
 
 =head2 season
@@ -962,8 +967,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2025-01-30 13:59:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:weoZv3p4ezhvsmPJgva1jg
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2025-02-12 11:29:51
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:pRbO1Wipm4vIgLcYzHFmqA
 
 use Try::Tiny;
 use DateTime::Duration;

--- a/lib/TopTable/Schema/Result/TeamMatchPlayer.pm
+++ b/lib/TopTable/Schema/Result/TeamMatchPlayer.pm
@@ -1080,7 +1080,9 @@ sub update_person {
       
       foreach my $stat ( @og_stats_deletable ) {
         # Delete but only if no matches are played
-        $stat->delete if $stat->matches_played == 0;
+        if ( $stat->matches_played == 0 and (($stat->result_source->has_column("doubles_games_played") and $stat->doubles_games_played == 0) or !$stat->result_source->has_column("doubles_games_played")) ) {
+          $stat->delete;
+        }
       }
     } elsif ( $match->started and $action ne "set-missing" and $action ne "remove" ) {
       # We're adding a player where there wasn't previously one (we don't do this for the other way round - removing a player where

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -4203,7 +4203,7 @@ msgid "events.tournaments.rounds.entry-list-doubles"
 msgstr "Player list"
 
 msgid "events.tournaments.rounds.entry-list.col-header-team"
-msgstr "Pair"
+msgstr "Team"
 
 msgid "events.legend.tournament.round.select-entrants"
 msgstr "Qualifiers"
@@ -5347,6 +5347,15 @@ msgstr "Set the league divisional positions for %1"
 
 msgid "admin.fixtures-grid.create-fixtures"
 msgstr "Create the league fixtures for %1"
+
+msgid "admin.tournament.group.create-matches"
+msgstr "Create the matches for %1 in %2."
+
+msgid "admin.tournament.round.create-matches"
+msgstr "Create the matches for %1 in %2."
+
+msgid "admin.tournament.round.delete-matches"
+msgstr "Delete the matches for %1 in %2."
 
 msgid "admin.fixtures-grid.delete-fixtures"
 msgstr "Delete the league fixtures for %1"
@@ -6749,8 +6758,11 @@ msgstr "Date (tick &#39;Week beginning&#39; to use team home nights)"
 msgid "tournaments.rounds.field.date-individual"
 msgstr "Date (leave blank to use the tournament date)"
 
-msgid "tournaments.rounds.field.venue"
-msgstr "Venue (optional)"
+msgid "tournaments.rounds.field.date-"
+msgstr "Date (leave blank to use the tournament date for singles or doubles; team tournaments tick &#39;Week beginning&#39; to use team home nights)"
+
+msgid "tournaments.rounds.field.venue-"
+msgstr "Venue (optional; for team tournaments leave blank for home venue)"
 
 msgid "tournaments.rounds.field.venue-team"
 msgstr "Venue (leave blank for home venue)"
@@ -6793,6 +6805,36 @@ msgstr "The matches for %1 have been created, so entrants to the round cannot be
 
 msgid "events.tournaments.rounds.entrants.delete.success"
 msgstr "The entry list for %1 has successfully been deleted; entrants must now be re-added to the round."
+
+msgid "events.tournaments.rounds.matches.create.error.group-round"
+msgstr "%1 is a group round, so matches are created in individual groups."
+
+msgid "events.tournaments.rounds.matches.create.error.round-has-no-entrants"
+msgstr "%1 does not have its entry list yet, set the entrants before creating matches."
+
+msgid "events.tournaments.rounds.matches.create.error.round-already-has-matches"
+msgstr "%1 already has its matches set."
+
+msgid "events.tournaments.rounds.matches.create.error.group-not-in-round"
+msgstr "The group specified doesn&#39;t belong to %1 in %2."
+
+msgid "events.tournaments.rounds.matches.create.error.group-not-specified"
+msgstr "%1 is a group round, so matches must be created in individual groups."
+
+msgid "events.tournaments.rounds.matches.create.error.comp-not-in-round"
+msgstr "%1 has been selected as the %2 team in match %3; however they are not on the entry list for the round."
+
+msgid "events.tournaments.rounds.matches.delete.error.group-round"
+msgstr "%1 is a group round, so matches are deleted in individual groups."
+
+msgid "events.tournaments.rounds.matches.delete.error.round-has-no-matches"
+msgstr "%1 has no matches, so matches to delete."
+
+msgid "events.tournaments.rounds.matches.delete.error.matches-have-results"
+msgstr "Some of the matches in %1 have results, so they can&#39;t be deleted."
+
+msgid "events.tournaments.rounds.delete-fixtures.success"
+msgstr "Deleted %1 matches from %2."
 
 msgid "tournaments.rounds.group.details"
 msgstr "Group %1 details"
@@ -6975,10 +7017,10 @@ msgid "events.tournaments.rounds.groups.create-fixtures.error.season-complete"
 msgstr "Matches cannot be created for this group, because the season it occurs in has been archived."
 
 msgid "events.tournaments.rounds.groups.create-fixtures.error.grid-positions-not-set"
-msgstr "Grid positions for this group must be set before the fixtures can be created."
+msgstr "Grid positions for %1 must be set before the fixtures can be created."
 
 msgid "events.tournaments.rounds.groups.create-fixtures.error.matches-already-exist"
-msgstr "Fixtures for this group have already been created."
+msgstr "Fixtures for %1 have already been created."
 
 msgid "events.tournaments.rounds.groups.create-fixtures.error.round-blank"
 msgstr "The date for round %1 has not been selected."
@@ -7028,6 +7070,15 @@ msgstr "You must set a handicap, or select &#39;Scratch (no handicap)&#39 or &#3
 msgid "events.tournaments.rounds.groups.create-fixtures.error.handicap-invalid"
 msgstr "The handicap for round %1, match %2 is invalid; it must be a positive number above 0."
 
+msgid "events.tournaments.rounds.create-matches.success"
+msgstr "%1 fixtures for %2 have been created."
+
+msgid "events.tournaments.rounds.groups.delete-matches.error.no-matches"
+msgstr "There are no matches in %1 to delete."
+
+msgid "events.tournaments.rounds.groups.delete-matches.error.matches-have-results"
+msgstr "Matches in %1 cannot be deleted because some of the matches have results."
+
 msgid "events.tournaments.rounds.groups.create-fixtures.entrant-used-too-many-times"
 msgstr "In round %1, %2 is used %3 times; each entrant in the group must only be used once per round."
 
@@ -7036,9 +7087,6 @@ msgstr "In round %1, there are entrants not being used - you must use all entran
 
 msgid "events.tournaments.rounds.groups.create-fixtures.entrants-unused-with-bye"
 msgstr "In round %1, there are entrants not being used - you must use all entrants in each round, other than one that has a bye."
-
-msgid "events.tournaments.create-fixtures.success"
-msgstr "%1 fixtures for the group have been created."
 
 msgid "events.tournaments.rounds.groups.delete.error.cannot-delete"
 msgstr "You cannot delete %1, as it has matches, or the season is now complete."
@@ -7051,6 +7099,15 @@ msgstr "Deleted %1 matches from %2."
 
 msgid "events.tournaments.rounds.groups.error.delete-failed"
 msgstr "Failed to delete matches."
+
+msgid "events.tournaments.rounds.groups.auto-qualifiers.error.all-matches-complete"
+msgstr "The number of automatic qualifiers can&#39; be changed because all matches in %1 are completed."
+
+msgid "events.tournaments.rounds.groups.members.error.matches-created"
+msgstr "Members of %1 can&#39;t be changed because the matches have been created already."
+
+msgid "events.tournaments.rounds.groups.grid.error.matches-created"
+msgstr "The fixtures grid setttings for %1 can&#39;t be changed because the matches have been created already."
 
 msgid "events.tournaments.rounds.form.error.match-template-invalid"
 msgstr "The round match template is invalid; select a valid one, or leave blank to use the default template for the event."
@@ -7075,6 +7132,21 @@ msgstr "Please submit a date for the round."
 
 msgid "events.tournaments.rounds.delete-matches.explain"
 msgstr "Delete %1 matches in %2?  The matches will need to be recreated."
+
+msgid "events.tournaments.rounds.create-matches.fieldset.match"
+msgstr "Match %1"
+
+msgid "events.tournaments.rounds.create-matches.field.home"
+msgstr "Home participant"
+
+msgid "events.tournaments.rounds.create-matches.field.away"
+msgstr "Away participant"
+
+msgid "events.tournaments.rounds.groups.create-fixtures.home"
+msgstr "home"
+
+msgid "events.tournaments.rounds.groups.create-fixtures.away"
+msgstr "away"
 
 msgid "events.tournaments.rounds.groups.create-matches.fieldset.match-round"
 msgstr "Round %1 of matches"

--- a/root/static/script/events/create-edit.js
+++ b/root/static/script/events/create-edit.js
@@ -91,7 +91,11 @@ function handle_tournament_type() {
     $("#finish-time-container").show();
     $("#season-details").show();
     $("#enter-online").show();
-    $("#week_beginning").prettyCheckable("uncheck");
+    
+    if ( $("#week_beginning").length ) {
+      $("#week_beginning").prettyCheckable("uncheck");
+    }
+    
     $("div.wb").hide();
   }
   

--- a/root/static/script/events/tournaments/rounds/create-matches.js
+++ b/root/static/script/events/tournaments/rounds/create-matches.js
@@ -1,0 +1,28 @@
+/**
+ *  Handle sorting action
+ *
+ *
+ */
+$(document).ready(function() {
+  $("input.handicap_award").on("change", function(){
+    let $this = $(this);
+    let match = $this.data("match");
+    
+    switch($this.val()) {
+      case "scratch":
+      case "set_later":
+        // Scratch, hide the handicap field
+        $("#match_" + match + "_handicap").val("0");
+        $("#match_" + match + "_handicap").prop("disabled", true);
+        $("#match_" + match + "_handicap_div").hide();
+        break;
+      case "home":
+      case "away":
+        // Handicap goes to home or away, show the handicap field
+        $("#match_" + match + "_handicap").val("");
+        $("#match_" + match + "_handicap").prop("disabled", false);
+        $("#match_" + match + "_handicap_div").show();
+        break;
+    }
+  });
+});

--- a/root/static/script/events/tournaments/rounds/hcp/view.js
+++ b/root/static/script/events/tournaments/rounds/hcp/view.js
@@ -66,6 +66,25 @@ $(document).ready(function() {
     width: "75px"
   });
   
+  let entrants_table = $("#entrants").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: 25,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+  });
+  
+  $("select[name=entrants_length]").chosen({
+    disable_search: true,
+    single_backstroke_delete: false,
+    allow_single_deselect: true,
+    width: "75px"
+  });
+  
   /*
     Responsive tabs
   */
@@ -76,6 +95,8 @@ $(document).ready(function() {
       if (tab.selector == "#matches") {
         // Redraw the adjustments table
         matches_table.responsive.recalc();
+      } else if (tab.selector == "#summary") {
+        entrants_table.responsive.recalc();
       }
     }
   });

--- a/root/templates/html/events/create-edit.ttkt
+++ b/root/templates/html/events/create-edit.ttkt
@@ -1,6 +1,5 @@
 [%
 USE zeroes = format("%02d");
-CALL c.log.debug("flashed: " _ c.flash.show_flashed);
 IF c.flash.show_flashed;
   SET event_name = c.flash.name;
   SET start_date = c.flash.start_date;
@@ -158,7 +157,7 @@ END;
   </div>
   
 [%
-IF event_detail.can_edit_default_templates;
+IF action == "create" OR event_detail.can_edit_default_templates;
   SET template_disabled = "";
 ELSE;
   SET template_disabled = ' disabled="disabled"';
@@ -504,7 +503,8 @@ IF action == "create" OR new_season;
   <legend>[% c.maketext("events.legend.tournament.first-round-details") %]</legend>
   
 [%
-  PROCESS "html/events/tournaments/rounds/fields.ttkt" first = 1;
+  SET entry_type = "unknown" IF action == "create";
+  PROCESS "html/events/tournaments/rounds/fields.ttkt" first = 1, entry_type = entry_type;
 -%]
 </fieldset>
 [%

--- a/root/templates/html/events/tournaments/rounds/create-matches.ttkt
+++ b/root/templates/html/events/tournaments/rounds/create-matches.ttkt
@@ -1,0 +1,147 @@
+<form method="post" action="[% form_action %]">
+
+<fieldset>
+[%
+# Loop through the matches in this round
+SET match = 1;
+CALL c.log.debug("matches: " _ round.number_of_matches);
+WHILE (match <= round.number_of_matches);
+-%]
+  <fieldset>
+  <legend class="sub">[% c.maketext("events.tournaments.rounds.groups.create-matches.fieldset.match", match) %]</legend>
+    <div class="label-field-container">
+      <label for="match_[% match %]_home">[% c.maketext("events.tournaments.rounds.groups.create-matches.field.match-participants") %]</label>
+      <div class="field-container">
+        <select id="match_[% match %]_home" name="match_[% match %]_home" data-placeholder="[% c.maketext("events.tournaments.rounds.groups.create-matches.field.home") %]" data-match="[% match %]">
+          <option value=""></option>
+[%
+  FOREACH entrant IN entrants;
+    IF c.flash.matches.item(match).home.id == entrant.object_id;
+      SET selected = ' selected="selected"';
+    ELSE;
+      SET selected = '';
+    END;
+-%]
+          <option value="[% entrant.object_id %]"[% selected %]>[% entrant.object_name | html_entity %]</option>
+[%
+  END;
+-%]
+        </select>
+[%
+  c.maketext("matches.versus-abbreviation");
+-%]
+        <select id="match_[% match %]_away" name="match_[% match %]_away" data-placeholder="[% c.maketext("events.tournaments.rounds.groups.create-matches.field.away") %]" data-match="[% match %]">
+          <option value=""></option>
+[%
+  FOREACH entrant IN entrants;
+    IF c.flash.matches.item(match).away.id == entrant.object_id;
+      SET selected = ' selected="selected"';
+    ELSE;
+      SET selected = '';
+    END;
+-%]
+          <option value="[% entrant.object_id %]"[% selected %]>[% entrant.object_name | html_entity %]</option>
+[%
+  END;
+-%]
+        </select>
+      </div>
+      <div class="clear-fix"></div>
+    </div>
+
+    <div class="label-field-container">
+      <label for="match_[% match %]_venue">[% c.maketext("events.tournaments.rounds.groups.create-matches.field.venue-override") %]</label>
+      <div class="field-container">
+        <select id="match_[% match %]_venue" name="match_[% match %]_venue" data-placeholder="[% c.maketext("events.tournaments.rounds.groups.create-matches.field.placeholder.venue") %]" data-match="[% match %]">
+          <option value=""></option>
+[%
+  FOREACH venue IN venues;
+    IF c.flash.matches.item(match).venue.id == venue.id;
+      SET selected = ' selected="selected"';
+    ELSE;
+      SET selected = '';
+    END;
+-%]
+          <option value="[% venue.id %]"[% selected %]>[% venue.name | html_entity %]</option>
+[%
+  END;
+-%]
+        </select>
+      </div>
+      <div class="clear-fix"></div>
+      
+      <label for="match_[% match %]_day">[% c.maketext("events.tournaments.rounds.groups.create-matches.field.day-override") %]</label>
+      <div class="field-container">
+        <select id="match_[% match %]_day" name="match_[% match %]_day" data-placeholder="[% c.maketext("events.tournaments.rounds.groups.create-matches.field.placeholder.day") %]" data-match="[% match %]">
+          <option value=""></option>
+[%
+  FOREACH day IN days;
+    IF c.flash.matches.item(match).day.id == day.id;
+      SET selected = ' selected="selected"';
+    ELSE;
+      SET selected = '';
+    END;
+-%]
+          <option value="[% day.id %]"[% selected %]>[% c.maketext("weekdays." _ day.weekday_number) %]</option>
+[%
+  END;
+-%]
+        </select>
+      </div>
+      <div class="clear-fix"></div>
+    </div>
+[%
+  IF round.match_template.handicapped;
+    SET fld = 'match_' _ match _ '_handicap_award';
+    SWITCH c.flash.matches.item(match).handicap.awarded_to;
+      CASE "scratch";
+        SET set_later_checked = "";
+        SET scratch_checked = ' checked="checked"';
+        SET home_checked = "";
+        SET away_checked = "";
+        SET handicap_display = ' style="display: none;"';
+      CASE ["set_later", ""];
+        SET set_later_checked = ' checked="checked"';
+        SET scratch_checked = "";
+        SET home_checked = "";
+        SET away_checked = "";
+        SET handicap_display = ' style="display: none;"';
+      CASE "home";
+        SET set_later_checked = "";
+        SET scratch_checked = "";
+        SET home_checked = ' selected="selected"';
+        SET away_checked = "";
+        SET handicap_display = "";
+      CASE "away";
+        SET set_later_checked = "";
+        SET scratch_checked = "";
+        SET home_checked = "";
+        SET away_checked = ' selected="selected"';
+        SET handicap_display = "";
+    END;
+-%]
+    <input type="radio" name="match_[% match %]_handicap_award" class="handicap_award" value="set_later" data-label="[% c.maketext("events.tournament.rounds.groups.create-matches.field.handicap-set-later") %]" data-match="[% match %]"[% set_later_checked %]>
+    <input type="radio" name="match_[% match %]_handicap_award" class="handicap_award" value="scratch" data-label="[% c.maketext("events.tournament.rounds.groups.create-matches.field.handicap-scratch") %]" data-match="[% match %]"[% scratch_checked %]>
+    <input type="radio" name="match_[% match %]_handicap_award" class="handicap_award" value="home" data-label="[% c.maketext("events.tournament.rounds.groups.create-matches.field.handicap-to-home") %]" data-match="[% match %]"[% home_checked %]>
+    <input type="radio" name="match_[% match %]_handicap_award" class="handicap_award" value="away" data-label="[% c.maketext("events.tournament.rounds.groups.create-matches.field.handicap-to-away") %]" data-match="[% match %]"[% home_checked %]>
+    <div class="clear-fix"></div>
+    <div class="label-field-container" id="match_[% match %]_handicap_div"[% handicap_display %]>
+      <label for="match_[% match %]_handicap">[% c.maketext("events.tournaments.rounds.groups.create-matches.field.handicap") %]</label>
+      <div class="field-container">
+[%
+      SET fld = 'match_' _ match _ '_handicap';
+-%]
+        <input type="number" id="match_[% match %]_handicap" min="1" name="match_[% match %]_handicap" value="[% c.flash.matches.item(match).handicap.headstart %]" />
+      </div>
+    </div>
+    <div class="clear-fix"></div>
+[%
+  END;
+-%]
+  </fieldset>
+[%
+  SET match = match + 1;
+END; # End WHILE match <= round.number_of_matches
+-%]
+<input type="submit" name="Submit" value="[% c.maketext("form.button.save") %]" />
+</form>

--- a/root/templates/html/matches/team/change-handicaps.ttkt
+++ b/root/templates/html/matches/team/change-handicaps.ttkt
@@ -23,7 +23,7 @@ away_team = match.team_season_away_team_season.full_name | html_entity;
   </div>
   
   <div class="label-field-container">
-    <label for="away_team_handicap">[% c.maketext("matches.cancel.points-awarded", away_team) %]</label>
+    <label for="away_team_handicap">[% c.maketext("matches.handicaps.points-headstart", away_team) %]</label>
     <div class="field-container">
       <input type="number" id="away_team_handicap" name="away_team_handicap" value="[% away_team_handicap OR "0" %]" />
     </div>


### PR DESCRIPTION
- **[New]** Matches can now be created for the knock-out rounds.
- **[New]** Matches can be deleted from the knock-out rounds.
- **[New]** Round creation / edit fills out the round_of field for all knock-out rounds, not just the first (user entry on first knock-out, calculated on subsequent ones).
- **[New]** TournamentRound result methods has_entrants, matches, number_of_matches.
- **[New]** TournamentRoundGroup match creation (where the group isn't using a grid) passes off to TournamentRound match creation routine, so code is shared.
- **[New]** TournamentRoundGroup can_[action] methods moved to can_update with private routines to check each one.
- **[Fix]** Match player update only deletes the stat if they've also not played any doubles games.