### PR TITLE
Champion! (tournament edition)

### DIFF
--- a/lib/TopTable/Schema/Result/Season.pm
+++ b/lib/TopTable/Schema/Result/Season.pm
@@ -631,6 +631,7 @@ sub league_matches {
     } elsif ( $mode eq "rearranged" ) {
       my $compare_field = "played_date";
       $where->{scheduled_date} = {"!=" => \$compare_field};
+      $where->{cancelled} = 0;
     } elsif ( $mode eq "missing-players" ) {
       $where->{"team_match_players.player_missing"} = 1;
       $attrib->{join} = "team_match_players";

--- a/lib/TopTable/Schema/Result/TournamentRound.pm
+++ b/lib/TopTable/Schema/Result/TournamentRound.pm
@@ -1354,6 +1354,17 @@ sub is_first_ko_round {
   }
 }
 
+=head2 is_final_round
+
+Return 1 if this is the final round, or 0 if not.
+
+=cut
+
+sub is_final_round {
+  my $self = shift;
+  return $self->round_of == 2 ? 1 : 0;
+}
+
 =head2 num_qualifiers
 
 The number of qualifiers to go through from this round.  If this is a group round, it'll be the minimum number of qualifiers that can go through (taken from the sum of automatic_qualifiers in all groups); if it's a knock-out round it'll be half the number of people in the group.

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -1690,12 +1690,6 @@ msgid "stats.label.average"
 msgstr "Won (%)"
 
 ### Tables / points adjustments
-msgid "tables.positions.1"
-msgstr "Champions"
-
-msgid "tables.positions.2"
-msgstr "Runners up"
-
 msgid "tables.adjustments.fields.action"
 msgstr "Action"
 
@@ -3575,6 +3569,24 @@ msgstr "Points lost"
 msgid "stats.table-heading.average"
 msgstr "%"
 
+msgid "stats.positions.team.1"
+msgstr "Champions"
+
+msgid "stats.positions.team.2"
+msgstr "Runners up"
+
+msgid "stats.positions.doubles.1"
+msgstr "Champions"
+
+msgid "stats.positions.doubles.2"
+msgstr "Runners up"
+
+msgid "stats.positions.singles.1"
+msgstr "Champion"
+
+msgid "stats.positions.singles.2"
+msgstr "Runner up"
+
 ### League Tables
 msgid "stats.no-teams"
 msgstr "No teams have been entered into this season."
@@ -4307,14 +4319,23 @@ msgid "reports.columns.loan-players.games-won"
 msgstr "Won"
 
 ## Rearranged matches columns
+msgid "reports.columns.rearranged-matches.scheduled-date-sort"
+msgstr "Original date (sort)"
+
 msgid "reports.columns.rearranged-matches.scheduled-date"
 msgstr "Original date"
+
+msgid "reports.columns.rearranged-matches.rescheduled-date-sort"
+msgstr "Rescheduled date (sort)"
 
 msgid "reports.columns.rearranged-matches.rescheduled-date"
 msgstr "Rescheduled date"
 
-msgid "reports.columns.rearranged-matches.division"
-msgstr "Division"
+msgid "reports.columns.rearranged-matches.competition-sort"
+msgstr "Competition (sort)"
+
+msgid "reports.columns.rearranged-matches.competition"
+msgstr "Competition"
 
 msgid "reports.columns.rearranged-matches.home-team"
 msgstr "Home team"
@@ -4329,11 +4350,17 @@ msgid "reports.columns.rearranged-matches.venue"
 msgstr "Venue"
 
 ## Cancelled matches columns
+msgid "reports.columns.cancelled-matches.date-sort"
+msgstr "Date (sort)"
+
 msgid "reports.columns.cancelled-matches.date"
 msgstr "Date"
 
-msgid "reports.columns.cancelled-matches.division"
-msgstr "Division"
+msgid "reports.columns.cancelled-matches.competition-sort"
+msgstr "Competition (sort)
+
+msgid "reports.columns.cancelled-matches.competition"
+msgstr "Competition"
 
 msgid "reports.columns.cancelled-matches.home-team"
 msgstr "Home team"
@@ -4348,11 +4375,17 @@ msgid "reports.columns.cancelled-matches.venue"
 msgstr "Venue"
 
 ## Matches with missing players columns
+msgid "reports.columns.missing-players.date-sort"
+msgstr "Date (sort)"
+
 msgid "reports.columns.missing-players.date"
 msgstr "Date"
 
-msgid "reports.columns.missing-players.division"
-msgstr "Division"
+msgid "reports.columns.missing-players.competition-sort"
+msgstr "Competition (sort)"
+
+msgid "reports.columns.missing-players.competition"
+msgstr "Competition"
 
 msgid "reports.columns.missing-players.home-team"
 msgstr "Home team"

--- a/root/templates/html/fixtures-results/view/group-competitions-no-date-check-score.ttkt
+++ b/root/templates/html/fixtures-results/view/group-competitions-no-date-check-score.ttkt
@@ -39,6 +39,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -69,6 +71,25 @@
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
       END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
+      END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
       SET away_uri_title = c.maketext("matches.link-title.team-league", away_team_html);
@@ -87,8 +108,8 @@
     <tr>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a href="[% home_team_uri %]">[% home_team.full_name | html_entity %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a href="[% away_team_uri %]">[% away_team.full_name | html_entity %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a href="[% home_team_uri %]">[% home_team.full_name | html_entity %]</a>[% home_pos_img %]</td>
+      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a href="[% away_team_uri %]">[% away_team.full_name | html_entity %]</a>[% away_pos_img %]</td>
 [%
     IF matches_started;
       # If some of the matches have been updated already, show the scores but no venue (this is a space saver, if matches have already)

--- a/root/templates/html/fixtures-results/view/group-competitions-no-date.ttkt
+++ b/root/templates/html/fixtures-results/view/group-competitions-no-date.ttkt
@@ -29,6 +29,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -59,6 +61,25 @@
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
       END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+      END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
       SET away_uri_title = c.maketext("matches.link-title.team-league", away_team_html);
@@ -77,8 +98,8 @@
     <tr>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team.full_name | html_entity %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team.full_name | html_entity %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
+      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%

--- a/root/templates/html/fixtures-results/view/group-competitions.ttkt
+++ b/root/templates/html/fixtures-results/view/group-competitions.ttkt
@@ -32,6 +32,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -62,6 +64,25 @@
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
       END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+      END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
       SET away_uri_title = c.maketext("matches.link-title.team-league", away_team_html);
@@ -90,8 +111,8 @@
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%

--- a/root/templates/html/fixtures-results/view/group-days-ordering-no-comp.ttkt
+++ b/root/templates/html/fixtures-results/view/group-days-ordering-no-comp.ttkt
@@ -38,6 +38,8 @@ SET round_class = " round_view" IF round_view;
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -53,6 +55,25 @@ SET round_class = " round_view" IF round_view;
       ELSE;
         SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
         SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
       END;
     ELSE;
       # Current season team links
@@ -81,8 +102,8 @@ SET round_class = " round_view" IF round_view;
     <td data-label="[% c.maketext("fixtures-results.heading.day") %]">[% date.day_name | ucfirst | html_entity %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date-sort") %]">[% date.ymd %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%

--- a/root/templates/html/fixtures-results/view/group-week-competitions.ttkt
+++ b/root/templates/html/fixtures-results/view/group-week-competitions.ttkt
@@ -38,6 +38,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -67,6 +69,25 @@
         ELSE;
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
       END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
@@ -104,8 +125,8 @@
     <td data-label="[% c.maketext("fixtures-results.heading.day") %]">[% played_date.day_name %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date-sort") %]">[% played_date.ymd %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(played_date) %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%

--- a/root/templates/html/fixtures-results/view/group-weeks-ordering-no-comp.ttkt
+++ b/root/templates/html/fixtures-results/view/group-weeks-ordering-no-comp.ttkt
@@ -37,6 +37,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -52,6 +54,25 @@
       ELSE;
         SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
         SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
       END;
     ELSE;
       # Current season team links
@@ -82,8 +103,8 @@
     <td data-label="[% c.maketext("fixtures-results.heading.day") %]">[% date.day_name | ucfirst | html_entity %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date-sort") %]">[% date.ymd %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%

--- a/root/templates/html/fixtures-results/view/group-weeks-ordering-no-venue.ttkt
+++ b/root/templates/html/fixtures-results/view/group-weeks-ordering-no-venue.ttkt
@@ -37,6 +37,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -66,6 +68,25 @@
         ELSE;
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
       END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
@@ -99,8 +120,8 @@
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
 [%
     IF authorisation.match_update OR authorisation.match_cancel;

--- a/root/templates/html/fixtures-results/view/group-weeks-ordering.ttkt
+++ b/root/templates/html/fixtures-results/view/group-weeks-ordering.ttkt
@@ -39,6 +39,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -68,6 +70,25 @@
         ELSE;
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
       END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
@@ -101,8 +122,8 @@
     <td data-label="[% c.maketext("fixtures-results.heading.day") %]">[% date.day_name %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date-sort") %]">[% date.ymd %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%

--- a/root/templates/html/fixtures-results/view/hcp/group-competitions-no-date-check-score.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-competitions-no-date-check-score.ttkt
@@ -41,6 +41,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -71,6 +73,25 @@
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
       END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
+      END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
       SET away_uri_title = c.maketext("matches.link-title.team-league", away_team_html);
@@ -89,9 +110,9 @@
     <tr>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
-      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
 [%
     IF matches_started;

--- a/root/templates/html/fixtures-results/view/hcp/group-competitions-no-date.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-competitions-no-date.ttkt
@@ -31,6 +31,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -61,6 +63,25 @@
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
       END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+      END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
       SET away_uri_title = c.maketext("matches.link-title.team-league", away_team_html);
@@ -79,9 +100,9 @@
     <tr>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
-      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>

--- a/root/templates/html/fixtures-results/view/hcp/group-competitions.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-competitions.ttkt
@@ -34,6 +34,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -64,6 +66,25 @@
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
       END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+      END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
       SET away_uri_title = c.maketext("matches.link-title.team-league", away_team_html);
@@ -92,9 +113,9 @@
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>

--- a/root/templates/html/fixtures-results/view/hcp/group-days-ordering-no-comp.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-days-ordering-no-comp.ttkt
@@ -40,6 +40,8 @@ SET round_class = " round_view" IF round_view
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -55,6 +57,25 @@ SET round_class = " round_view" IF round_view
       ELSE;
         SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
         SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="16" height="16" />';
       END;
     ELSE;
       # Current season team links
@@ -83,9 +104,9 @@ SET round_class = " round_view" IF round_view
     <td data-label="[% c.maketext("fixtures-results.heading.day") %]">[% date.day_name %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date-sort") %]">[% date.ymd %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>

--- a/root/templates/html/fixtures-results/view/hcp/group-week-competitions.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-week-competitions.ttkt
@@ -40,6 +40,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -69,6 +71,25 @@
         ELSE;
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
       END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
@@ -102,9 +123,9 @@
     <td data-label="[% c.maketext("fixtures-results.heading.day") %]">[% played_date.day_name %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date-sort") %]">[% played_date.ymd %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(played_date) %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>

--- a/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering-no-comp.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering-no-comp.ttkt
@@ -39,6 +39,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -54,6 +56,25 @@
       ELSE;
         SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
         SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
       END;
     ELSE;
       # Current season team links
@@ -84,9 +105,9 @@
     <td data-label="[% c.maketext("fixtures-results.heading.day") %]">[% date.day_name %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date-sort") %]">[% date.ymd %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>

--- a/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering-no-venue.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering-no-venue.ttkt
@@ -39,6 +39,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -68,6 +70,25 @@
         ELSE;
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
       END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
@@ -101,9 +122,9 @@
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
 [%

--- a/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/group-weeks-ordering.ttkt
@@ -41,6 +41,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -70,6 +72,25 @@
         ELSE;
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
       END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
@@ -109,9 +130,9 @@
     <td data-label="[% c.maketext("fixtures-results.heading.day") %]">[% date.day_name %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date-sort") %]">[% date.ymd %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
-    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
-    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+    <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
     <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
     <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>

--- a/root/templates/html/fixtures-results/view/hcp/no-grouping.ttkt
+++ b/root/templates/html/fixtures-results/view/hcp/no-grouping.ttkt
@@ -33,6 +33,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -62,6 +64,25 @@
         ELSE;
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
       END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
@@ -94,9 +115,9 @@
       <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.home-team-hcp-full") %]">[% match.handicap_format("home") OR "&nbsp;" %]</td>
-      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.away-team-hcp-full") %]">[% match.handicap_format("away") OR "&nbsp;" %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>

--- a/root/templates/html/fixtures-results/view/no-grouping.ttkt
+++ b/root/templates/html/fixtures-results/view/no-grouping.ttkt
@@ -32,6 +32,8 @@
     SET away_team = match.team_season_away_team_season;
     home_team_html = home_team.full_name | html_entity;
     away_team_html = away_team.full_name | html_entity;
+    SET home_pos_img = "";
+    SET away_pos_img = "";
     
     IF match.tournament_round;
       SET tourn_round = match.tournament_round;
@@ -61,6 +63,25 @@
         ELSE;
           SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
         END;
+      END;
+      
+      IF match.complete AND match.winner AND match.is_final;
+        IF match.winner.id == home_team.team.id;
+          # Home win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.1");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.2");
+        ELSIF match.winner.id == away_team.team.id;
+          # Away win
+          SET home_trophy_img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
+          SET home_trophy_alt = c.maketext("stats.positions.team.2");
+          SET away_trophy_img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
+          SET away_trophy_alt = c.maketext("stats.positions.team.1");
+        END;
+        
+        SET home_pos_img = ' <img src="' _ home_trophy_img_src _ '" title="' _ home_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
+        SET away_pos_img = ' <img src="' _ away_trophy_img_src _ '" title="' _ away_trophy_alt _ '" alt="' _ home_trophy_alt _ '" width="32" height="32" />';
       END;
     ELSE;
       SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
@@ -93,8 +114,8 @@
       <td data-label="[% c.maketext("fixtures-results.heading.date") %]"><a href="[% fixtures_day_uri %]">[% c.i18n_datetime_format_date.format_datetime(date) %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.competition-sort") %]">[% match.competition_sort %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
-      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
+      <td data-label="[% c.maketext("fixtures-results.heading.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a>[% home_pos_img %]</td>
+      <td data-label="[% c.maketext("fixtures-results.heading.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a>[% away_pos_img %]</td>
       <td data-label="[% c.maketext("fixtures-results.heading.score-versus") %]"><a href="[% c.uri_for_action('/matches/team/view_by_url_keys', match.url_keys) %]" title="[% c.maketext("fixtures-results.view-scorecard") %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("fixtures-results.heading.venue") %]"><a href="[% c.uri_for_action('/venues/view', [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
 [%

--- a/root/templates/html/reports/cancelled-matches.ttkt
+++ b/root/templates/html/reports/cancelled-matches.ttkt
@@ -18,8 +18,8 @@ IF report_data.count;
     <tr>
       <th>[% c.maketext("reports.columns.cancelled-matches.date") %]</th>
       <th>[% c.maketext("reports.columns.cancelled-matches.date") %]</th>
-      <th>[% c.maketext("reports.columns.cancelled-matches.division") %]</th>
-      <th>[% c.maketext("reports.columns.cancelled-matches.division") %]</th>
+      <th>[% c.maketext("reports.columns.cancelled-matches.competition-sort") %]</th>
+      <th>[% c.maketext("reports.columns.cancelled-matches.competition") %]</th>
       <th>[% c.maketext("reports.columns.cancelled-matches.home-team") %]</th>
       <th>[% c.maketext("reports.columns.cancelled-matches.away-team") %]</th>
       <th>[% c.maketext("reports.columns.cancelled-matches.score-versus") %]</th>
@@ -33,35 +33,64 @@ IF report_data.count;
     SET year = match.scheduled_date.year;
     SET month = zeroes(match.scheduled_date.month);
     SET day = zeroes(match.scheduled_date.day);
-    SET home_season = match.team_season_home_team_season;
-    SET home_club = home_season.club_season.club.url_key;
-    SET home_team = home_season.team.url_key;
-    SET home_name = home_season.club_season.short_name _ " " _ home_season.name;
+    SET home_team = match.team_season_home_team_season;
+    SET away_team = match.team_season_away_team_season;
+    home_team_html = home_team.full_name | html_entity;
+    away_team_html = away_team.full_name | html_entity;
     
-    SET away_season = match.team_season_away_team_season;
-    SET away_club = away_season.club_season.club.url_key;
-    SET away_team = away_season.team.url_key;
-    SET away_name = away_season.club_season.short_name _ " " _ away_season.name;
-    
-    IF specific_season;
-      SET home_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [home_team, home_team, season.url_key]);
-      SET away_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [away_club, away_team, season.url_key]);
-      SET table_uri = c.uri_for_action("/league-tables/view_specific_season", [match.division_season.division.url_key, season.url_key]);
+    IF match.tournament_round;
+      SET tourn_round = match.tournament_round;
+      SET tourn = tourn_round.tournament;
+      SET event = tourn.event_season.event;
+      event_html = event.name | html_entity;
+      SET home_uri_title = c.maketext("matches.link-title.team-tournament", home_team_html, event_html);
+      SET away_uri_title = c.maketext("matches.link-title.team-tournament", away_team_html, event_html);
+      
+      IF specific_season;
+        SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_specific_season", [event.url_key, season.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
+        SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_specific_season", [event.url_key, season.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      ELSE;
+        SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
+        SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      END;
+      
+      IF match.tournament_group;
+        IF specific_season;
+          SET comp_uri = c.uri_for_action("/events/group_view_specific_season", [match.tournament_round.tournament.event_season.event.url_key, season.url_key, match.tournament_round.url_key, match.tournament_group.url_key]);
+        ELSE;
+          SET comp_uri = c.uri_for_action("/events/group_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key, match.tournament_group.url_key]);
+        END;
+      ELSE;
+        IF specific_season;
+          SET comp_uri = c.uri_for_action("/events/round_view_specific_season", [match.tournament_round.tournament.event_season.event.url_key, season.url_key, match.tournament_round.url_key]);
+        ELSE;
+          SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
+        END;
+      END;
     ELSE;
-      SET home_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [home_club, home_team]);
-      SET away_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [away_club, away_team]);
-      SET table_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
+      SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
+      SET away_uri_title = c.maketext("matches.link-title.team-league", away_team_html);
+      
+      IF specific_season;
+        SET home_team_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [home_team.club_season.club.url_key, home_team.team.url_key, season.url_key]);
+        SET away_team_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [away_team.club_season.club.url_key, away_team.team.url_key, season.url_key]);
+        SET comp_uri = c.uri_for_action("/league-tables/view_specific_season", [match.division_season.division.url_key, season.url_key]);
+      ELSE;
+        SET home_team_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [home_team.club_season.club.url_key, home_team.team.url_key]);
+        SET away_team_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [away_team.club_season.club.url_key, away_team.team.url_key]);
+        SET comp_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
+      END;
     END;
 -%]
     <tr>
-      <td data-label="[% c.maketext("reports.columns.cancelled-matches.date") %]">[% match.played_date.ymd %]</td>
+      <td data-label="[% c.maketext("reports.columns.cancelled-matches.date-sort") %]">[% match.played_date.ymd %]</td>
       <td data-label="[% c.maketext("reports.columns.cancelled-matches.date") %]">[% c.i18n_datetime_format_date.format_datetime(match.played_date) %]</td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.division") %]">[% match.division_season.division.rank %]</td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.division") %]"><a href="[% table_uri %]">[% match.division_season.name | html %]</a></td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.home-team") %]"><a href="[% home_uri %]">[% home_name | html_entity %]</a></td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.away-team") %]"><a href="[% away_uri %]">[% away_name | html_entity %]</a></td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.score-versus") %]"><a href="[% c.uri_for_action("/matches/team/view_by_url_keys", match.url_keys) %]">[% match.home_team_match_score _ "-" _ match.away_team_match_score %]</a></td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.cancelled-matches.competition-sort") %]">[% match.competition_sort %]</td>
+      <td data-label="[% c.maketext("reports.columns.cancelled-matches.competition") %]"><a href="[% comp_uri %]">[% match.competition_name %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.cancelled-matches.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html | html_entity %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.cancelled-matches.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html | html_entity %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.cancelled-matches.score-versus") %]"><a href="[% c.uri_for_action("/matches/team/view_by_url_keys", match.url_keys) %]">[% match.home_team_match_score _ "-" _ match.away_team_match_score %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.cancelled-matches.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
     </tr>
 [%
   END;

--- a/root/templates/html/reports/missing-players.ttkt
+++ b/root/templates/html/reports/missing-players.ttkt
@@ -17,10 +17,10 @@ IF report_data.count;
 <table id="report" class="stripe hover order-column row-border" style="width: 100%;">
   <thead>
     <tr>
+      <th>[% c.maketext("reports.columns.missing-players.date-sort") %]</th>
       <th>[% c.maketext("reports.columns.missing-players.date") %]</th>
-      <th>[% c.maketext("reports.columns.missing-players.date") %]</th>
-      <th>[% c.maketext("reports.columns.missing-players.division") %]</th>
-      <th>[% c.maketext("reports.columns.missing-players.division") %]</th>
+      <th>[% c.maketext("reports.columns.missing-players.competition-sort") %]</th>
+      <th>[% c.maketext("reports.columns.missing-players.competition") %]</th>
       <th>[% c.maketext("reports.columns.missing-players.home-team") %]</th>
       <th>[% c.maketext("reports.columns.missing-players.away-team") %]</th>
       <th>[% c.maketext("reports.columns.missing-players.players-missing") %]</th>
@@ -35,33 +35,62 @@ IF report_data.count;
     SET year = match.scheduled_date.year;
     SET month = zeroes(match.scheduled_date.month);
     SET day = zeroes(match.scheduled_date.day);
-    SET home_season = match.team_season_home_team_season;
-    SET home_club = home_season.club_season.club.url_key;
-    SET home_team = home_season.team.url_key;
-    SET home_name = home_season.club_season.short_name _ " " _ home_season.name;
+    SET home_team = match.team_season_home_team_season;
+    SET away_team = match.team_season_away_team_season;
+    home_team_html = home_team.full_name | html_entity;
+    away_team_html = away_team.full_name | html_entity;
     
-    SET away_season = match.team_season_away_team_season;
-    SET away_club = away_season.club_season.club.url_key;
-    SET away_team = away_season.team.url_key;
-    SET away_name = away_season.club_season.short_name _ " " _ away_season.name;
-    
-    IF specific_season;
-      SET home_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [home_team, home_team, season.url_key]);
-      SET away_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [away_club, away_team, season.url_key]);
-      SET table_uri = c.uri_for_action("/league-tables/view_specific_season", [match.division_season.division.url_key, season.url_key]);
+    IF match.tournament_round;
+      SET tourn_round = match.tournament_round;
+      SET tourn = tourn_round.tournament;
+      SET event = tourn.event_season.event;
+      event_html = event.name | html_entity;
+      SET home_uri_title = c.maketext("matches.link-title.team-tournament", home_team_html, event_html);
+      SET away_uri_title = c.maketext("matches.link-title.team-tournament", away_team_html, event_html);
+      
+      IF specific_season;
+        SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_specific_season", [event.url_key, season.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
+        SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_specific_season", [event.url_key, season.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      ELSE;
+        SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
+        SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      END;
+      
+      IF match.tournament_group;
+        IF specific_season;
+          SET comp_uri = c.uri_for_action("/events/group_view_specific_season", [match.tournament_round.tournament.event_season.event.url_key, season.url_key, match.tournament_round.url_key, match.tournament_group.url_key]);
+        ELSE;
+          SET comp_uri = c.uri_for_action("/events/group_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key, match.tournament_group.url_key]);
+        END;
+      ELSE;
+        IF specific_season;
+          SET comp_uri = c.uri_for_action("/events/round_view_specific_season", [match.tournament_round.tournament.event_season.event.url_key, season.url_key, match.tournament_round.url_key]);
+        ELSE;
+          SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
+        END;
+      END;
     ELSE;
-      SET home_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [home_club, home_team]);
-      SET away_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [away_club, away_team]);
-      SET table_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
+      SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
+      SET away_uri_title = c.maketext("matches.link-title.team-league", away_team_html);
+      
+      IF specific_season;
+        SET home_team_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [home_team.club_season.club.url_key, home_team.team.url_key, season.url_key]);
+        SET away_team_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [away_team.club_season.club.url_key, away_team.team.url_key, season.url_key]);
+        SET comp_uri = c.uri_for_action("/league-tables/view_specific_season", [match.division_season.division.url_key, season.url_key]);
+      ELSE;
+        SET home_team_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [home_team.club_season.club.url_key, home_team.team.url_key]);
+        SET away_team_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [away_team.club_season.club.url_key, away_team.team.url_key]);
+        SET comp_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
+      END;
     END;
 -%]
     <tr>
-      <td data-label="[% c.maketext("reports.columns.missing-players.date") %]">[% match.played_date.ymd %]</td>
+      <td data-label="[% c.maketext("reports.columns.missing-players.date-sort") %]">[% match.played_date.ymd %]</td>
       <td data-label="[% c.maketext("reports.columns.missing-players.date") %]">[% c.i18n_datetime_format_date.format_datetime(match.played_date) %]</td>
-      <td data-label="[% c.maketext("reports.columns.missing-players.division") %]">[% match.division_season.division.rank %]</td>
-      <td data-label="[% c.maketext("reports.columns.missing-players.division") %]"><a href="[% table_uri %]">[% match.division_season.name | html %]</a></td>
-      <td data-label="[% c.maketext("reports.columns.missing-players.home-team") %]"><a href="[% home_uri %]">[% home_name | html_entity %]</a></td>
-      <td data-label="[% c.maketext("reports.columns.missing-players.away-team") %]"><a href="[% away_uri %]">[% away_name | html_entity %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.missing-players.competition-sort") %]">[% match.competition_sort %]</td>
+      <td data-label="[% c.maketext("reports.columns.missing-players.competition") %]"><a href="[% table_uri %]">[% match.competition_name %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.missing-players.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.missing-players.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
       <td data-label="[% c.maketext("reports.columns.missing-players.players-missing") %]">[% match.players_absent %]</td>
       <td data-label="[% c.maketext("reports.columns.missing-players.score-versus") %]"><a href="[% c.uri_for_action("/matches/team/view_by_url_keys", match.url_keys) %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("reports.columns.missing-players.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>

--- a/root/templates/html/reports/rearranged-matches.ttkt
+++ b/root/templates/html/reports/rearranged-matches.ttkt
@@ -17,12 +17,12 @@ IF report_data.count;
 <table id="report" class="stripe hover order-column row-border" style="width: 100%;">
   <thead>
     <tr>
+      <th>[% c.maketext("reports.columns.rearranged-matches.scheduled-date-sort") %]</th>
       <th>[% c.maketext("reports.columns.rearranged-matches.scheduled-date") %]</th>
-      <th>[% c.maketext("reports.columns.rearranged-matches.scheduled-date") %]</th>
+      <th>[% c.maketext("reports.columns.rearranged-matches.rescheduled-date-sort") %]</th>
       <th>[% c.maketext("reports.columns.rearranged-matches.rescheduled-date") %]</th>
-      <th>[% c.maketext("reports.columns.rearranged-matches.rescheduled-date") %]</th>
-      <th>[% c.maketext("reports.columns.rearranged-matches.division") %]</th>
-      <th>[% c.maketext("reports.columns.rearranged-matches.division") %]</th>
+      <th>[% c.maketext("reports.columns.rearranged-matches.competition-sort") %]</th>
+      <th>[% c.maketext("reports.columns.rearranged-matches.competition") %]</th>
       <th>[% c.maketext("reports.columns.rearranged-matches.home-team") %]</th>
       <th>[% c.maketext("reports.columns.rearranged-matches.away-team") %]</th>
       <th>[% c.maketext("reports.columns.rearranged-matches.score-versus") %]</th>
@@ -36,35 +36,64 @@ IF report_data.count;
     SET year = match.scheduled_date.year;
     SET month = zeroes(match.scheduled_date.month);
     SET day = zeroes(match.scheduled_date.day);
-    SET home_season = match.team_season_home_team_season;
-    SET home_club = home_season.club_season.club.url_key;
-    SET home_team = home_season.team.url_key;
-    SET home_name = home_season.club_season.short_name _ " " _ home_season.name;
+    SET home_team = match.team_season_home_team_season;
+    SET away_team = match.team_season_away_team_season;
+    home_team_html = home_team.full_name | html_entity;
+    away_team_html = away_team.full_name | html_entity;
     
-    SET away_season = match.team_season_away_team_season;
-    SET away_club = away_season.club_season.club.url_key;
-    SET away_team = away_season.team.url_key;
-    SET away_name = away_season.club_season.short_name _ " " _ away_season.name;
-    
-    IF specific_season;
-      SET home_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [home_team, home_team, season.url_key]);
-      SET away_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [away_club, away_team, season.url_key]);
-      SET table_uri = c.uri_for_action("/league-tables/view_specific_season", [match.division_season.division.url_key, season.url_key]);
+    IF match.tournament_round;
+      SET tourn_round = match.tournament_round;
+      SET tourn = tourn_round.tournament;
+      SET event = tourn.event_season.event;
+      event_html = event.name | html_entity;
+      SET home_uri_title = c.maketext("matches.link-title.team-tournament", home_team_html, event_html);
+      SET away_uri_title = c.maketext("matches.link-title.team-tournament", away_team_html, event_html);
+      
+      IF specific_season;
+        SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_specific_season", [event.url_key, season.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
+        SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_specific_season", [event.url_key, season.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      ELSE;
+        SET home_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, home_team.club_season.club.url_key, home_team.team.url_key]);
+        SET away_team_uri = c.uri_for_action("/events/teams_view_by_url_key_current_season", [event.url_key, away_team.club_season.club.url_key, away_team.team.url_key]);
+      END;
+      
+      IF match.tournament_group;
+        IF specific_season;
+          SET comp_uri = c.uri_for_action("/events/group_view_specific_season", [match.tournament_round.tournament.event_season.event.url_key, season.url_key, match.tournament_round.url_key, match.tournament_group.url_key]);
+        ELSE;
+          SET comp_uri = c.uri_for_action("/events/group_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key, match.tournament_group.url_key]);
+        END;
+      ELSE;
+        IF specific_season;
+          SET comp_uri = c.uri_for_action("/events/round_view_specific_season", [match.tournament_round.tournament.event_season.event.url_key, season.url_key, match.tournament_round.url_key]);
+        ELSE;
+          SET comp_uri = c.uri_for_action("/events/round_view_current_season", [match.tournament_round.tournament.event_season.event.url_key, match.tournament_round.url_key]);
+        END;
+      END;
     ELSE;
-      SET home_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [home_club, home_team]);
-      SET away_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [away_club, away_team]);
-      SET table_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
+      SET home_uri_title = c.maketext("matches.link-title.team-league", home_team_html);
+      SET away_uri_title = c.maketext("matches.link-title.team-league", away_team_html);
+      
+      IF specific_season;
+        SET home_team_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [home_team.club_season.club.url_key, home_team.team.url_key, season.url_key]);
+        SET away_team_uri = c.uri_for_action("/teams/view_specific_season_by_url_key", [away_team.club_season.club.url_key, away_team.team.url_key, season.url_key]);
+        SET comp_uri = c.uri_for_action("/league-tables/view_specific_season", [match.division_season.division.url_key, season.url_key]);
+      ELSE;
+        SET home_team_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [home_team.club_season.club.url_key, home_team.team.url_key]);
+        SET away_team_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [away_team.club_season.club.url_key, away_team.team.url_key]);
+        SET comp_uri = c.uri_for_action("/league-tables/view_current_season", [match.division_season.division.url_key]);
+      END;
     END;
 -%]
     <tr>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.scheduled-date") %]">[% match.scheduled_date.ymd("") %]</td>
+      <td data-label="[% c.maketext("reports.columns.rearranged-matches.scheduled-date-sort") %]">[% match.scheduled_date.ymd("") %]</td>
       <td data-label="[% c.maketext("reports.columns.rearranged-matches.scheduled-date") %]">[% c.i18n_datetime_format_date.format_datetime(match.scheduled_date) %]</td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.rescheduled-date") %]">[% match.played_date.ymd("") %]</td>
+      <td data-label="[% c.maketext("reports.columns.rearranged-matches.rescheduled-date-sort") %]">[% match.played_date.ymd("") %]</td>
       <td data-label="[% c.maketext("reports.columns.rearranged-matches.rescheduled-date") %]">[% c.i18n_datetime_format_date.format_datetime(match.played_date) %]</td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.division") %]">[% match.division_season.division.rank %]</td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.division") %]"><a href="[% table_uri %]">[% match.division_season.name | html %]</a></td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.home-team") %]"><a href="[% home_uri %]">[% home_name | html_entity %]</a></td>
-      <td data-label="[% c.maketext("reports.columns.rearranged-matches.away-team") %]"><a href="[% away_uri %]">[% away_name | html_entity %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.rearranged-matches.competition-sort") %]">[% match.competition_sort %]</td>
+      <td data-label="[% c.maketext("reports.columns.rearranged-matches.competition") %]"><a href="[% table_uri %]">[% match.competition_name %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.rearranged-matches.home-team") %]"><a title="[% home_uri_title %]" href="[% home_team_uri %]">[% home_team_html %]</a></td>
+      <td data-label="[% c.maketext("reports.columns.rearranged-matches.away-team") %]"><a title="[% away_uri_title %]" href="[% away_team_uri %]">[% away_team_html %]</a></td>
       <td data-label="[% c.maketext("reports.columns.rearranged-matches.score-versus") %]"><a href="[% c.uri_for_action("/matches/team/view_by_url_keys", match.url_keys) %]">[% match.score %]</a></td>
       <td data-label="[% c.maketext("reports.columns.rearranged-matches.venue") %]"><a href="[% c.uri_for_action("/venues/view", [match.venue.url_key]) %]">[% match.venue.name | html_entity %]</a></td>
     </tr>

--- a/root/templates/html/tables/table.ttkt
+++ b/root/templates/html/tables/table.ttkt
@@ -86,19 +86,18 @@ FOREACH entrant = entrants;
   END;
   
   # If the table is complete, show trophy icons instead of position numbers in the top two positions
-  CALL c.log.debug("complete: " _ table_complete);
   IF table_complete;
     SWITCH i;
       CASE [1, 2];
         # First or second place - setup image.  Img src depends on specific place:
         SWITCH i;
           CASE 1;
-            SET img_src = c.uri_for("/static/images/icons/trophy-1st-16.png");
+            SET img_src = c.uri_for("/static/images/icons/trophy-1st-32.png");
           CASE 2;
-            SET img_src = c.uri_for("/static/images/icons/trophy-2nd-16.png");
+            SET img_src = c.uri_for("/static/images/icons/trophy-2nd-32.png");
         END;
         
-        SET pos_display = '<img src="' _ img_src _ '" title="' _ c.maketext("tables.positions." _ i) _ '" width="16" height="16" />';
+        SET pos_display = '<img src="' _ img_src _ '" title="' _ c.maketext("stats.positions.team." _ i) _ '" width="32" height="32" />';
       CASE 2;
         # Second place
         SET pos_display = "text";


### PR DESCRIPTION
- **[New]** Matches that are a tournament final (when complete) show the 1st place trophy icon next to the winner and 2nd place next to the loser.
- **[New]** New TeamMatch results method is_final (boolean return) and is_winner (team object return, or undef if no winner).
- **[New]** New TournamentRound result method is_final_round (boolean return).
- **[New]** Fixtures views show 1st / 2nd place trophy icons next to the relevant teams where the match is the final of a tournament.
- **[New]** Altered the trophy icons in league tables view to 32px from 16px.
- **[Fix]** Rearranged matches report no longer includes rearranged matches that were subsequently cancelled.