### PR TITLE
Error detail for sysadmins

### DIFF
--- a/lib/TopTable/Schema/Result/User.pm
+++ b/lib/TopTable/Schema/Result/User.pm
@@ -1422,6 +1422,17 @@ sub search_display {
   };
 }
 
+=head2 sysadmin
+
+Returns true if the user is a sysadmin.
+
+=cut
+
+sub sysadmin {
+  my $self = shift;
+  return $self->has_role($self->result_source->schema->resultset("Role")->find({sysadmin => 1}));
+}
+
 =head2 registered_long_date
 
 Return the long registered date.

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -6526,6 +6526,9 @@ msgstr "User"
 msgid "error.info.user.not-logged-in"
 msgstr "Anonymous"
 
+msgid "error.info.error"
+msgstr "Error %1"
+
 msgid "footer.copyright"
 msgstr "Copyright"
 

--- a/root/templates/html/error/500.ttkt
+++ b/root/templates/html/error/500.ttkt
@@ -86,6 +86,20 @@ ELSE;
 END;
 -%]</td>
       </tr>
+[%
+IF c.user_exists AND c.user.sysadmin;
+  SET error_num = 0;
+  FOREACH error = errors;
+    SET error_num = error_num + 1;
+-%]
+      <tr>
+        <th scope="row">[% c.maketext("error.info.error", error_num) %]</th>
+        <td>[% error %]</td>
+      </tr>
+[%
+  END;
+END;
+-%]
     </table>
   </div>
 </div>


### PR DESCRIPTION
- **[New]** Added error detail to the 500 error page, only if the user is logged in as the sysadmin.
- **[New]** New User result method sysadmin to check if the user is a sysadmin user.