### PR TITLE
Select entrants from completed KO rounds

### DIFF
--- a/lib/TopTable/Controller/Events.pm
+++ b/lib/TopTable/Controller/Events.pm
@@ -1669,6 +1669,7 @@ sub round_select_entrants :Chained("rounds_current_season") :PathPart("select-en
   my $js = "select-entrants";
   $js .= "-points" if defined($ranking_template) and $ranking_template->assign_points;
   $js .= "-hcp" if $match_template->handicapped;
+  $js .= "-ko" unless $round->group_round;
   $js = $c->uri_for("/static/script/events/tournaments/rounds/$js.js");
   
   my @auto_qualifiers = $prev_round->auto_qualifiers;

--- a/lib/TopTable/Schema/Result/TeamMatchGame.pm
+++ b/lib/TopTable/Schema/Result/TeamMatchGame.pm
@@ -1678,12 +1678,18 @@ sub update_score {
     # To work out who's won, we need to know which value we're checking by the winner type
     if ( $current_home_match_score > $current_away_match_score ) {
       $match_new_winner = "home";
+      $match->winner($home_team->id);
     } elsif ( $current_away_match_score > $current_home_match_score ) {
       $match_new_winner = "away";
+      $match->winner($away_team->id);
     } else {
       # Equal scores: draw
       $match_new_winner = "draw";
+      $match->winner(undef);
     }
+  } else {
+    # Match not complete
+    $match->winner(undef);
   }
   
   # Score adjustments for matches / games played / won / lost / drawn.  Should be -1, 0 or 1 to take 1, make no adjustment or add 1 to that value

--- a/lib/TopTable/Schema/Result/TeamSeason.pm
+++ b/lib/TopTable/Schema/Result/TeamSeason.pm
@@ -860,6 +860,21 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 team_matches_winner_seasons
+
+Type: has_many
+
+Related object: L<TopTable::Schema::Result::TeamMatch>
+
+=cut
+
+__PACKAGE__->has_many(
+  "team_matches_winner_seasons",
+  "TopTable::Schema::Result::TeamMatch",
+  { "foreign.season" => "self.season", "foreign.winner" => "self.team" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 team_points_adjustments
 
 Type: has_many
@@ -891,8 +906,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2025-02-28 09:16:11
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Bt1YivqMRWTbRGzr0x176w
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2025-02-28 10:30:32
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:vJioYl4OU+/ERVGYZRCZYg
 
 __PACKAGE__->add_columns(
     "last_updated",

--- a/lib/TopTable/Schema/Result/Tournament.pm
+++ b/lib/TopTable/Schema/Result/Tournament.pm
@@ -857,7 +857,7 @@ sub calculate_ko_rounds {
   my $ko = $self->first_ko_round;
   
   # If the round is complete, we'll take the entrants that have been setup, otherwise take the entered value
-  my $players = $ko->complete ? $ko->get_entrants : $ko->round_of;
+  my $players = $ko->complete ? $ko->get_entrants->count : $ko->round_of;
   
   # Rounds is base 2 logarithm of the number of players, rounded up (ceil).
   my $rounds = ceil(logn($players, 2));

--- a/root/static/script/events/tournaments/rounds/select-entrants-hcp-ko.js
+++ b/root/static/script/events/tournaments/rounds/select-entrants-hcp-ko.js
@@ -1,0 +1,145 @@
+/**
+ *  Initialise datatable
+ *
+ */
+$(document).ready(function() {
+  $("#auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: 10,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Entrant (team / player / pair)
+      responsivePriority: 1,
+      targets: 0
+    }, {
+      // Matches played
+      responsivePriority: 7,
+      targets: 1
+    }, {
+      // Won
+      responsivePriority: 5,
+      targets: 2
+    }, {
+      // Drawn
+      responsivePriority: 8,
+      targets: 3
+    }, {
+      // Lost
+      responsivePriority: 6,
+      targets: 4
+    }, {
+      // For
+      responsivePriority: 3,
+      targets: 5
+    }, {
+      // Against
+      responsivePriority: 4,
+      targets: 6
+    }, {
+      // Handicap
+      responsivePriority: 9,
+      targets: 7
+    }, {
+      // Points / games difference
+      responsivePriority: 2,
+      targets: 8
+    }]
+  });
+  
+  let select_tb = $("#non-auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: -1,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Selection ID (hidden)
+      visible: 0,
+      targets: 0
+    }, {
+      // Section checkbox
+      responsivePriority: 1,
+      targets: 1
+    }, {
+      // Group
+      responsivePriority: 13,
+      targets: 2
+    }, {
+      // Group position
+      responsivePriority: 3,
+      targets: 3
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 2,
+      targets: 4
+    }, {
+      // Matches played
+      responsivePriority: 10,
+      targets: 5
+    }, {
+      // Won
+      responsivePriority: 8,
+      targets: 6
+    }, {
+      // Drawn
+      responsivePriority: 11,
+      targets: 7
+    }, {
+      // Lost
+      responsivePriority: 9,
+      targets: 8
+    }, {
+      // For
+      responsivePriority: 6,
+      targets: 9
+    }, {
+      // Against
+      responsivePriority: 7,
+      targets: 10
+    }, {
+      // Handicap
+      responsivePriority: 12,
+      targets: 11
+    }, {
+      // Points / games difference
+      responsivePriority: 5,
+      targets: 12
+    }, {
+      // Points
+      responsivePriority: 4,
+      targets: 13
+    }]
+  });
+  
+  select_tb.on("click", "tbody tr", function(event) {
+    let ent_id = select_tb.row(this).data()[0];
+    
+    if ( event.target.localName !== "a" ) {
+      // Toggle checked property
+      if ( $("#select-" + ent_id).prop("checked") ) {
+        $("#select-" + ent_id).prettyCheckable("uncheck");
+      } else {
+        $("#select-" + ent_id).prettyCheckable("check");
+      }
+    }
+  });
+  
+  $("select[name=auto-table_length], select[name=non-auto-table_length]").chosen({
+    disable_search: true,
+    single_backstroke_delete: false,
+    allow_single_deselect: true,
+    width: "75px"
+  });
+  
+  $("#accordion").accordion({heightStyle: "content"});
+});

--- a/root/static/script/events/tournaments/rounds/select-entrants-hcp.js
+++ b/root/static/script/events/tournaments/rounds/select-entrants-hcp.js
@@ -1,0 +1,153 @@
+/**
+ *  Initialise datatable
+ *
+ */
+$(document).ready(function() {
+  $("#auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: 10,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Group
+      responsivePriority: 13,
+      targets: 0
+    }, {
+      // Group position
+      responsivePriority: 3,
+      targets: 1
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 2,
+      targets: 2
+    }, {
+      // Matches played
+      responsivePriority: 9,
+      targets: 3
+    }, {
+      // Won
+      responsivePriority: 7,
+      targets: 4
+    }, {
+      // Drawn
+      responsivePriority: 10,
+      targets: 5
+    }, {
+      // Lost
+      responsivePriority: 8,
+      targets: 6
+    }, {
+      // For
+      responsivePriority: 5,
+      targets: 7
+    }, {
+      // Against
+      responsivePriority: 6,
+      targets: 8
+    }, {
+      // Handicap
+      responsivePriority: 11,
+      targets: 9
+    }, {
+      // Points / games difference
+      responsivePriority: 4,
+      targets: 10
+    }]
+  });
+  
+  let select_tb = $("#non-auto-table").DataTable({
+    responsive: true,
+    paging: true,
+    pageLength: -1,
+    lengthChange: true,
+    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    info: true,
+    fixedHeader: true,
+    searching: true,
+    ordering: false,
+    columnDefs: [{
+      // Selection ID (hidden)
+      visible: 0,
+      targets: 0
+    }, {
+      // Section checkbox
+      responsivePriority: 1,
+      targets: 1
+    }, {
+      // Group
+      responsivePriority: 13,
+      targets: 2
+    }, {
+      // Group position
+      responsivePriority: 3,
+      targets: 3
+    }, {
+      // Entrant (team / player / pair)
+      responsivePriority: 2,
+      targets: 4
+    }, {
+      // Matches played
+      responsivePriority: 10,
+      targets: 5
+    }, {
+      // Won
+      responsivePriority: 8,
+      targets: 6
+    }, {
+      // Drawn
+      responsivePriority: 11,
+      targets: 7
+    }, {
+      // Lost
+      responsivePriority: 9,
+      targets: 8
+    }, {
+      // For
+      responsivePriority: 6,
+      targets: 9
+    }, {
+      // Against
+      responsivePriority: 7,
+      targets: 10
+    }, {
+      // Handicap
+      responsivePriority: 12,
+      targets: 11
+    }, {
+      // Points / games difference
+      responsivePriority: 5,
+      targets: 12
+    }, {
+      // Points
+      responsivePriority: 4,
+      targets: 13
+    }]
+  });
+  
+  select_tb.on("click", "tbody tr", function(event) {
+    let ent_id = select_tb.row(this).data()[0];
+    
+    if ( event.target.localName !== "a" ) {
+      // Toggle checked property
+      if ( $("#select-" + ent_id).prop("checked") ) {
+        $("#select-" + ent_id).prettyCheckable("uncheck");
+      } else {
+        $("#select-" + ent_id).prettyCheckable("check");
+      }
+    }
+  });
+  
+  $("select[name=auto-table_length], select[name=non-auto-table_length]").chosen({
+    disable_search: true,
+    single_backstroke_delete: false,
+    allow_single_deselect: true,
+    width: "75px"
+  });
+  
+  $("#accordion").accordion({heightStyle: "content"});
+});

--- a/root/templates/html/events/tournaments/rounds/select-entrants.ttkt
+++ b/root/templates/html/events/tournaments/rounds/select-entrants.ttkt
@@ -30,8 +30,14 @@ IF round_number > 1;
           <table class="stripe hover row-border" id="auto-table">
             <thead>
               <tr>
+[%
+  IF round.group_round;
+-%]
                 <th>[% c.maketext("events.tournament.rounds.entrants.group") %]</th>
                 <th>[% c.maketext("events.tournament.rounds.entrants.group-pos") %]</th>
+[%
+  END;
+-%]
                 <th>[% c.maketext("stats.table-heading.team") %]</th>
                 <th class="numeric" title="[% c.maketext("stats.table-heading.team-matches-played.full") %]">[% c.maketext("stats.table-heading.team-matches-played") %]</th>
                 <th class="numeric" title="[% c.maketext("stats.table-heading.matches-won.full") %]">[% c.maketext("stats.table-heading.matches-won") %]</th>
@@ -70,8 +76,14 @@ IF round_number > 1;
     END;
 -%]
                     <tr>
+[%
+  IF round.group_round;
+-%]
                       <td data-label="[% c.maketext("events.tournament.rounds.entrants.group") %]">[% entrant.tournament_group.name %]</td>
                       <td data-label="[% c.maketext("events.tournament.rounds.entrants.group-pos") %]">[% entrant.group_position %]</td>
+[%
+  END;
+-%]
                       <td data-label="[% c.maketext("stats.table-heading.team") %]">[% entrant.object_name | html_entity %]</td>
                       <td data-label="[% c.maketext("stats.table-heading.team-matches-played.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_played) %]</td>
                       <td data-label="[% c.maketext("stats.table-heading.matches-won.full") %]" class="numeric">[% c.i18n_numberformat.format_number(entrant.matches_won) %]</td>


### PR DESCRIPTION
- **[New]** Entrants can now be selected from the previous round even if it's a knock-out round.
- **[New]** New winner column in team matches - match update routines (score update, match cancellation and score override) now set this when the match is complete and not a draw.  There is a manual SQL update requirement to update existing matches.
- **[Fix]** Fix to calculating the number of KO rounds where the first KO round is complete (this was passing in the resultset of entrants, rather than the number of entrants).