### PR TITLE
Interesting season stats!

### DIFF
--- a/lib/TopTable/Controller/Divisions.pm
+++ b/lib/TopTable/Controller/Divisions.pm
@@ -176,12 +176,7 @@ sub view_current_season :Chained("view") :PathPart("") :Args(0) {
   my $enc_name = $c->stash->{enc_name};
   
   # No season ID, try to find the current season
-  my $season = $c->model("DB::Season")->get_current;
-  
-  if ( !defined($season) ) {
-    # No current season season, try and find the last season.
-    $season = $c->model("DB::Season")->last_complete_season;
-  }
+  my $season = $c->model("DB::Season")->get_current_or_last;
   
   if ( defined($season) ) {
     $c->stash({

--- a/lib/TopTable/Controller/Events.pm
+++ b/lib/TopTable/Controller/Events.pm
@@ -276,7 +276,7 @@ sub create :Local {
   # Check that we are authorised to create events
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["event_create", $c->maketext("user.auth.create-events"), 1]);
   
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   unless ( defined($current_season) ) {
     # Redirect and show the error
@@ -3209,7 +3209,7 @@ sub edit_details :Chained("base") :PathPart("edit-details") :Args(0) {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["event_edit", $c->maketext("user.auth.edit-events"), 1]);  # Try to find the current season (or the last completed season if there is no current season)
   
   # Check we have a current season to edit (we can't edit archived seasons' events)
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
     
   if ( defined($current_season) ) {
     # Forward to the routine that stashes the event's season details
@@ -3370,7 +3370,7 @@ sub do_edit_details :Chained("base") :PathPart("do-edit-details") :Args(0) {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["event_edit", $c->maketext("user.auth.edit-events"), 1]);  # Try to find the current season (or the last completed season if there is no current season)
   
   # Check we have a current season to edit (we can't edit archived seasons' events)
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
     
   if ( defined($current_season) ) {
     # Forward to the routine that stashes the event's season details

--- a/lib/TopTable/Controller/FixturesGrids.pm
+++ b/lib/TopTable/Controller/FixturesGrids.pm
@@ -789,7 +789,7 @@ sub teams :Chained("base") :PathPart("teams") :Args(0) {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["fixtures_edit", $c->maketext("user.auth.edit-fixtures-grids"), 1]);
   
   # Get the current season, so we know which teams and divisions we have.
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   # Check we have a current season
   unless ( defined($current_season) ) {
@@ -860,7 +860,7 @@ sub set_teams :Chained("base") :PathPart("set-teams") :Args(0) {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["fixtures_edit", $c->maketext("user.auth.edit-fixtures-grids"), 1]);
   
   # Get the current season, so we know which teams and divisions we have.
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   # Check we have a current season
   unless ( defined($current_season) ) {
@@ -953,7 +953,7 @@ sub create_fixtures :Chained("base") :PathPart("create-fixtures") :Args(0) {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["fixtures_create", $c->maketext("user.auth.create-fixtures"), 1]);
   
   # Get the current season, so we know which teams and divisions we have.
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   # Check we have a current season
   unless ( defined($current_season) ) {
@@ -1033,7 +1033,7 @@ sub do_create_fixtures :Chained("base") :PathPart("do-create-fixtures") :Args(0)
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["fixtures_create", $c->maketext("user.auth.create-fixtures"), 1]);
   
   # Check we have a current season
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   # Check we have a current season
   unless ( defined($current_season) ) {

--- a/lib/TopTable/Controller/FixturesResults.pm
+++ b/lib/TopTable/Controller/FixturesResults.pm
@@ -337,7 +337,7 @@ sub filter_view :Private {
   
   if ( $view_method eq "teams" ) {
     # View by team; display a list of teams
-    $display_options = [$c->model("DB::TeamMatchCountsView")->search_by_season($season)];
+    $display_options = [$c->model("DB::VwTeamMatchCounts")->search_by_season($season)];
     $view_method_display = $c->maketext("fixtures-results.title.category.by-team");
     push(@external_scripts,
       $c->uri_for("/static/script/plugins/datatables/dataTables.rowGroup.min.js"),
@@ -360,7 +360,7 @@ sub filter_view :Private {
     push(@external_styles, $c->uri_for("/static/css/datatables/rowGroup.dataTables.min.css"));
   } elsif ( $view_method eq "weeks" ) {
     # View by week; display a list of weeks with matches
-    $display_options = [$c->model("DB::TeamMatchWeeksView")->search_by_season($season)];
+    $display_options = [$c->model("DB::VwTeamMatchWeeks")->search_by_season($season)];
     $view_method_display = $c->maketext("fixtures-results.title.category.by-week");
     push(@external_scripts,
       $c->uri_for("/static/script/plugins/datatables/dataTables.rowGroup.min.js"),

--- a/lib/TopTable/Controller/Info.pm
+++ b/lib/TopTable/Controller/Info.pm
@@ -346,9 +346,9 @@ sub team_captains :Path("team-captains") :Args(1) {
   my ( $self, $c, $view_by ) = @_;
   
   # Check there's a current season, otherwise we'll error
-  my $season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
-  unless ( defined($season) ) {
+  unless ( defined($current_season) ) {
     # Error, no current season
     $c->response->redirect($c->uri_for("/",
                                 {mid => $c->set_status_msg({error => $c->maketext("team-captains.view.error.no-current-season")})}));
@@ -377,7 +377,7 @@ sub team_captains :Path("team-captains") :Args(1) {
     template => sprintf("html/info/team-captains/view-%s.ttkt", $view_by),
     subtitle1 => $c->maketext("menu.text.captains"),
     subtitle2 => $c->maketext(sprintf("menu.text.captains.%s", $view_by)),
-    teams => scalar $c->model("DB::Team")->get_teams_with_captains_in_season({season => $season, view_by => $view_by}),
+    teams => scalar $c->model("DB::Team")->get_teams_with_captains_in_season({season => $current_season, view_by => $view_by}),
     external_scripts => [
       $c->uri_for("/static/script/plugins/chosen/chosen.jquery.min.js"),
       $c->uri_for("/static/script/plugins/datatables/dataTables.min.js"),

--- a/lib/TopTable/Controller/Info/Officials.pm
+++ b/lib/TopTable/Controller/Info/Officials.pm
@@ -219,7 +219,7 @@ sub reorder :Path("reorder") {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["committee_edit", $c->maketext("user.auth.edit-officials"), 1]);
   
   # Get the current season, so we know which teams and divisions we have.
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   # Check we have a current season
   unless ( defined($current_season) ) {

--- a/lib/TopTable/Controller/Info/Officials/Positions.pm
+++ b/lib/TopTable/Controller/Info/Officials/Positions.pm
@@ -121,7 +121,7 @@ sub create :Local {
   # Check that we are authorised to create committee positions
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["committee_create", $c->maketext("user.auth.create-officials"), 1]);
   
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   # Check we have a current season
   unless ( defined($current_season) ) {
@@ -208,7 +208,7 @@ sub edit :Chained("base") :PathPart("edit") :Args(0) {
   # Check that we are authorised to create committee positions
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["committee_edit", $c->maketext("user.auth.edit-officials"), 1]);
   
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   # Check we have a current season
   unless ( defined($current_season) ) {

--- a/lib/TopTable/Controller/Matches/Team.pm
+++ b/lib/TopTable/Controller/Matches/Team.pm
@@ -1664,7 +1664,7 @@ sub search :Local :Args(0) {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["match_view", $c->maketext("user.auth.view-matches"), 1]);
   
   $c->stash({
-    db_resultset => "TeamMatchView",
+    db_resultset => "VwTeamMatch",
     query_params => {
       q => $c->req->params->{q},
       include_complete => $c->req->params->{complete},

--- a/lib/TopTable/Controller/Meetings.pm
+++ b/lib/TopTable/Controller/Meetings.pm
@@ -781,7 +781,7 @@ sub process_form :Private {
   # If it's an event, work out if we can edit (we must be editing, can't create through this method).
   if ( $is_event ) {
     my ( $season, $event_season );
-    $season = $c->model("DB::Season")->get_current;
+    my $current_season = $c->stash->{current_season};
     
     if ( defined($season) ) {
       $event_season = $meeting->event_season;

--- a/lib/TopTable/Controller/People.pm
+++ b/lib/TopTable/Controller/People.pm
@@ -674,7 +674,7 @@ sub create :Chained("base_no_object_specified") :PathPart("create") :CaptureArgs
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["person_create", $c->maketext("user.auth.create-people"), 1]);
   
   # Get the current season
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   unless ( defined($current_season) ) {
     # Redirect and show the error
@@ -888,7 +888,7 @@ sub edit :Chained("base") :PathPart("edit") :Args(0) {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["person_edit", $c->maketext("user.auth.edit-people"), 1]);
   
   # Get the current season
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   unless ( defined($current_season) ) {
     # Redirect and show the error
@@ -1200,7 +1200,7 @@ sub process_form :Private {
   my @processed_field_names = qw( first_name surname change_name_prev_seasons address1 address2 address3 address4 address5 postcode home_telephone mobile_telephone work_telephone email_address gender date_of_birth team captain_of secretary_of registration_date fees_paid user noindex );
   
   # Get the current season
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   unless ( defined( $current_season ) ) {
     # Redirect and show the error
@@ -1279,7 +1279,7 @@ sub import :Local {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["person_create", $c->maketext("user.auth.create-people"), 1]);
   
   # Get the current season
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   unless ( defined($current_season) ) {
     # Redirect and show the error
@@ -1326,7 +1326,7 @@ sub import_results :Path("import-results") {
   my @allowed_types = qw( text/plain text/csv );
   
   # Get the current season
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   if ( defined($current_season) ) {
     # Stash the current season

--- a/lib/TopTable/Controller/Search.pm
+++ b/lib/TopTable/Controller/Search.pm
@@ -42,7 +42,7 @@ sub index :Path :Args(0) {
   push(@include_types, qw( template-league-table-ranking template-match-individual template-match-team )) if $c->stash->{authorisation}{template_view};
   
   $c->stash({
-    db_resultset => "SearchAllView",
+    db_resultset => "VwSearchAll",
     query_params => {
       q => $c->req->params->{q},
       include_types => \@include_types
@@ -133,7 +133,7 @@ sub do_search {
         $json_result->{name} = ( $result->result_source->schema->source($db_resultset)->has_column("date") and defined($result->date) ) ? sprintf("%s (%s)", $display{name}, $result->date->dmy("/")) : $display{name};
         
         
-        if ( $type eq "person" and $db_resultset ne "SearchAllView" ) {
+        if ( $type eq "person" and $db_resultset ne "VwSearchAll" ) {
           # Additional formatting options for people
           $json_result->{initial_and_surname} = $result->initial_and_surname;
           $json_result->{initials} = $result->initials;

--- a/lib/TopTable/Controller/Teams.pm
+++ b/lib/TopTable/Controller/Teams.pm
@@ -941,7 +941,7 @@ sub create :Chained("base_create") :PathPart("create") :CaptureArgs(0) {
   $c->forward( "TopTable::Controller::Users", "check_authorisation", ["team_create", $c->maketext("user.auth.create-teams"), 1] );
   
   # Get the current season
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   if ( defined($current_season) ) {
     # If there us a current season, we need to check we haven't progressed through
@@ -1105,7 +1105,7 @@ sub edit :Private {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["team_edit", $c->maketext("user.auth.edit-teams"), 1]);
   
   # Get the current season
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   if ( !defined($current_season) ) {
     # Redirect and show the error
@@ -1218,7 +1218,6 @@ sub edit :Private {
     clubs => scalar $c->model("DB::Club")->all_clubs_by_name,
     divisions => $divisions,
     home_nights => scalar $c->model("DB::LookupWeekday")->all_days,
-    current_season => $current_season,
     team_season => $team_season,
     last_team_season => $last_team_season,
     form_action => $c->uri_for_action("/teams/do_edit_by_url_key", [$team->club->url_key, $team->url_key]),
@@ -1341,7 +1340,7 @@ sub points_adjustment :Private {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["team_points_adjust", $c->maketext("user.auth.team-points-adjust"), 1]);
   
   # Get the current season
-  my $current_season = $c->model("DB::Season")->get_current;
+  my $current_season = $c->stash->{current_season};
   
   if ( !defined($current_season) ) {
     # Redirect and show the error
@@ -1626,7 +1625,7 @@ sub search :Local :Args(0) {
   $c->forward("TopTable::Controller::Users", "check_authorisation", ["team_view", $c->maketext("user.auth.view-teams"), 1]);
   
   $c->stash({
-    db_resultset => "ClubTeamView",
+    db_resultset => "VwClubTeam",
     query_params => {q => $c->req->params->{q}},
     view_action => "/teams/view_current_season_by_url_key",
     search_action => "/teams/search",

--- a/lib/TopTable/Schema/Result/VwClubTeam.pm
+++ b/lib/TopTable/Schema/Result/VwClubTeam.pm
@@ -1,8 +1,8 @@
-package TopTable::Schema::Result::ClubTeamView;
+package TopTable::Schema::Result::VwClubTeam;
 
 =head1 NAME
 
-TopTable::Schema::Result::ClubTeamView
+TopTable::Schema::Result::VwClubTeam - a view to get the team information and club together for searching.
 
 =cut
 
@@ -30,13 +30,13 @@ extends 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
 
-=head1 VIEW: C<club_teams>
+=head1 VIEW: C<vw_club_teams>
 
 =cut
 
 __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
 
-__PACKAGE__->table("club_teams");
+__PACKAGE__->table("vw_club_teams");
 __PACKAGE__->result_source_instance->is_virtual(1);
 __PACKAGE__->result_source_instance->view_definition(
   "SELECT c.id AS 'club_id', c.url_key AS 'club_url_key', t.id AS 'team_id', t.url_key AS 'team_url_key', s.id AS 'season_id', s.url_key AS 'season_url_key', s.name AS 'season_name', s.start_date AS 'season_start_date', s.end_date AS 'season_end_date', s.complete AS 'season_complete', CONCAT(c.short_name, ' ', t.name) AS 'team_with_club', CONCAT(c.abbreviated_name, ' ', t.name) AS 'abbreviated_team_with_club', c.full_name AS 'club_full_name'

--- a/lib/TopTable/Schema/Result/VwHighestPointsWin.pm
+++ b/lib/TopTable/Schema/Result/VwHighestPointsWin.pm
@@ -1,0 +1,359 @@
+package TopTable::Schema::Result::VwHighestPointsWin;
+
+=head1 NAME
+
+TopTable::Schema::Result::VwHighestPointsWin - a view to show the highest number of points for a win in legs.  Will only retrieve deuce legs to save on rows coming back, therefore at the very start of the season, even if games have been played, this may not return anything.
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=item * L<DBIx::Class::PassphraseColumn>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
+
+=head1 VIEW: C<vw_match_leg_deuces>
+
+=cut
+
+__PACKAGE__->table_class('DBIx::Class::ResultSource::View');
+
+__PACKAGE__->table("vw_highest_points_win");
+__PACKAGE__->result_source_instance->is_virtual(1);
+__PACKAGE__->result_source_instance->view_definition(
+  "SELECT player_id, player_url_key, player_first_name, player_surname, player_display_name, opponent_id, opponent_url_key, opponent_first_name, opponent_surname, opponent_display_name, season_id, season_url_key, season_name, season_start_date, season_end_date, season_complete, home_team_id, home_club_url_key, home_team_url_key, away_team_id, away_club_url_key, away_team_url_key, scheduled_date, played_date, home_team, away_team, division_id, division_url_key, division_name, tourn_id, tourn_url_key, tourn_name, winning_points, losing_points, scheduled_game_number, leg_number
+FROM ((
+	SELECT
+		g.home_player AS player_id,
+		p.url_key AS player_url_key,
+		ps.first_name AS player_first_name,
+		ps.surname AS player_surname,
+		ps.display_name AS player_display_name,
+		g.away_player AS opponent_id,
+		o.url_key AS opponent_url_key,
+		os.first_name AS opponent_first_name,
+		os.surname AS opponent_surname,
+		os.display_name AS opponent_display_name,
+		ht.id AS home_team_id,
+		hc.url_key AS home_club_url_key,
+		ht.url_key AS home_team_url_key,
+		`at`.id AS away_team_id,
+		ac.url_key AS away_club_url_key,
+		`at`.url_key AS away_team_url_key,
+		m.scheduled_date AS scheduled_date,
+		m.played_date AS played_date,
+		CONCAT(hcs.short_name, ' ', hts.`name`) AS home_team,
+		CONCAT(acs.short_name, ' ', ats.`name`) AS away_team,
+		g.scheduled_game_number AS scheduled_game_number,
+		l.leg_number AS leg_number,
+		s.id AS season_id,
+		s.url_key AS season_url_key,
+		s.`name` AS season_name,
+		s.start_date AS season_start_date,
+		s.end_date AS season_end_date,
+		s.complete AS season_complete,
+		d.id AS division_id,
+		d.url_key AS division_url_key,
+		ds.`name` AS division_name,
+		e.url_key AS tourn_url_key,
+		tou.id AS tourn_id,
+		tou.`name` AS tourn_name,
+		l.home_team_points_won AS winning_points,
+		l.away_team_points_won AS losing_points
+	FROM team_match_legs l
+	JOIN team_match_games g ON l.home_team = g.home_team AND l.away_team = g.away_team AND l.scheduled_date = g.scheduled_date AND l.scheduled_game_number = g.scheduled_game_number
+	JOIN team_matches m ON g.home_team = m.home_team AND g.away_team = m.away_team AND g.scheduled_date = m.scheduled_date
+	JOIN template_match_individual tpl ON g.individual_match_template = tpl.id
+	JOIN seasons s ON m.season = s.id
+	LEFT JOIN division_seasons ds ON m.division = ds.division AND m.season = ds.season
+	LEFT JOIN divisions d ON ds.division = d.id
+	LEFT JOIN tournament_rounds tr ON m.tournament_round = tr.id
+	LEFT JOIN tournaments tou ON tr.`event` = tou.`event` AND tr.season = tou.season
+	LEFT JOIN `events` e ON tou.`event` = e.id
+	JOIN people p ON g.home_player = p.id
+	JOIN person_seasons ps ON p.id = ps.person AND s.id = ps.season AND ps.team = m.home_team
+	JOIN people o ON g.away_player = o.id -- opponent
+	JOIN person_seasons os ON o.id = os.person AND s.id = os.season AND os.team = m.away_team
+	JOIN teams ht ON m.home_team = ht.id
+	JOIN team_seasons hts ON m.home_team = hts.team AND m.season = hts.season
+	JOIN clubs hc ON ht.club = hc.id
+	JOIN club_seasons hcs ON hts.club = hcs.club AND hts.season = hcs.season
+	JOIN teams `at` ON m.away_team = `at`.id
+	JOIN team_seasons ats ON m.away_team = ats.team AND m.season = ats.season
+	JOIN clubs ac ON `at`.club = ac.id
+	JOIN club_seasons acs ON ats.club = acs.club AND ats.season = acs.season
+	WHERE l.home_team_points_won > l.away_team_points_won AND l.home_team_points_won > tpl.minimum_points_win
+	ORDER BY l.home_team_points_won)
+	UNION ALL
+	(
+	SELECT
+		g.away_player AS player_id,
+		p.url_key AS player_url_key,
+		ps.first_name AS player_first_name,
+		ps.surname AS player_surname,
+		ps.display_name AS player_display_name,
+		g.home_player AS opponent_id,
+		o.url_key AS opponent_url_key,
+		os.first_name AS opponent_first_name,
+		os.surname AS opponent_surname,
+		os.display_name AS opponent_display_name,
+		ht.id AS home_team_id,
+		hc.url_key AS home_club_url_key,
+		ht.url_key AS home_team_url_key,
+		`at`.id AS away_team_id,
+		ac.url_key AS away_club_url_key,
+		`at`.url_key AS away_team_url_key,
+		m.scheduled_date AS scheduled_date,
+		m.played_date AS played_date,
+		CONCAT(hcs.short_name, ' ', hts.`name`) AS home_team,
+		CONCAT(acs.short_name, ' ', ats.`name`) AS away_team,
+		g.scheduled_game_number AS scheduled_game_number,
+		l.leg_number AS leg_number,
+		s.id AS season_id,
+		s.url_key AS season_url_key,
+		s.`name` AS season_name,
+		s.start_date AS season_start_date,
+		s.end_date AS season_end_date,
+		s.complete AS season_complete,
+		d.id AS division_id,
+		d.url_key AS division_url_key,
+		ds.`name` AS division_name,
+		tou.id AS tourn_id,
+		e.url_key AS tourn_url_key,
+		tou.`name` AS tourn_name,
+		l.away_team_points_won AS winning_points,
+		l.home_team_points_won AS losing_points
+	FROM team_match_legs l
+	JOIN team_match_games g ON l.home_team = g.home_team AND l.away_team = g.away_team AND l.scheduled_date = g.scheduled_date AND l.scheduled_game_number = g.scheduled_game_number
+	JOIN team_matches m ON g.home_team = m.home_team AND g.away_team = m.away_team AND g.scheduled_date = m.scheduled_date
+	JOIN template_match_individual tpl ON g.individual_match_template = tpl.id
+	JOIN seasons s ON m.season = s.id
+	LEFT JOIN division_seasons ds ON m.division = ds.division AND m.season = ds.season
+	LEFT JOIN divisions d ON ds.division = d.id
+	LEFT JOIN tournament_rounds tr ON m.tournament_round = tr.id
+	LEFT JOIN tournaments tou ON tr.`event` = tou.`event` AND tr.season = tou.season
+	LEFT JOIN `events` e ON tou.`event` = e.id
+	JOIN people p ON g.away_player = p.id
+	JOIN person_seasons ps ON p.id = ps.person AND s.id = ps.season AND ps.team = m.away_team
+	JOIN people o ON g.home_player = o.id -- opponent
+	JOIN person_seasons os ON o.id = os.person AND s.id = os.season AND os.team = m.home_team
+	JOIN teams ht ON m.home_team = ht.id
+	JOIN team_seasons hts ON m.home_team = hts.team AND m.season = hts.season
+	JOIN clubs hc ON ht.club = hc.id
+	JOIN club_seasons hcs ON hts.club = hcs.club AND hts.season = hcs.season
+	JOIN teams `at` ON m.away_team = `at`.id
+	JOIN team_seasons ats ON m.away_team = ats.team AND m.season = ats.season
+	JOIN clubs ac ON `at`.club = ac.id
+	JOIN club_seasons acs ON ats.club = acs.club AND ats.season = acs.season
+	WHERE l.home_team_points_won < l.away_team_points_won AND l.away_team_points_won > tpl.minimum_points_win)) AS games
+GROUP BY player_id, season_id, winning_points"
+);
+
+__PACKAGE__->add_columns(
+  "player_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "player_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 45
+  },
+  "player_first_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150
+  },
+  "player_surname" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150
+  },
+  "player_display_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 301
+  },
+  "opponent_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "opponent_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 45
+  },
+  "opponent_first_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150
+  },
+  "opponent_surname" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150
+  },
+  "opponent_display_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 301
+  },
+  "season_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_auto_increment => 1,
+    is_nullable => 0,
+  },
+  "season_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 30,
+  },
+  "season_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150,
+  },
+  "season_start_date" => {
+    data_type => "date",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 0
+  },
+  "season_end_date" => {
+    data_type => "date",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 0
+  },
+  "season_complete" => {
+    data_type => "tinyint",
+    default_value => 0,
+    is_nullable => 0
+  },
+  "home_team_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_auto_increment => 1,
+    is_nullable => 0,
+  },
+  "home_club_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 45
+  },
+  "home_team_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 45
+  },
+  "away_team_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_auto_increment => 1,
+    is_nullable => 0,
+  },
+  "away_club_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 45
+  },
+  "away_team_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 45
+  },
+  "scheduled_date" => {
+    data_type => "date",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 0
+  },
+  "played_date" => {
+    data_type => "date",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 0
+  },
+  "home_team" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 301
+  },
+  "away_team" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 301
+  },
+  "division_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 1,
+  },
+  "division_url_key" => {
+    data_type => "varchar",
+    is_nullable => 1,
+    size => 45
+  },
+  "division_name" => {
+    data_type => "varchar",
+    is_nullable => 1,
+    size => 150
+  },
+  "tourn_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 1,
+  },
+  "tourn_url_key" => {
+    data_type => "varchar",
+    is_nullable => 1,
+    size => 45
+  },
+  "tourn_name" => {
+    data_type => "varchar",
+    is_nullable => 1,
+    size => 150
+  },
+  "winning_points" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "losing_points" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "scheduled_game_number" => {
+    data_type => "smallint",
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "leg_number" => {
+    data_type => "smallint",
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+);
+
+__PACKAGE__->set_primary_key("home_club_url_key", "home_team_url_key", "away_club_url_key", "away_team_url_key", "scheduled_date", "scheduled_game_number", "leg_number", "season_id");
+
+
+1;

--- a/lib/TopTable/Schema/Result/VwMatchDecidingGame.pm
+++ b/lib/TopTable/Schema/Result/VwMatchDecidingGame.pm
@@ -1,0 +1,190 @@
+package TopTable::Schema::Result::VwMatchDecidingGame;
+
+=head1 NAME
+
+TopTable::Schema::Result::VwMatchDecidingGame - a view to group together the deciding set wins and losses by person / season.
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=item * L<DBIx::Class::PassphraseColumn>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
+
+=head1 VIEW: C<vw_match_deciding_sets>
+
+=cut
+
+__PACKAGE__->table_class('DBIx::Class::ResultSource::View');
+
+__PACKAGE__->table("vw_match_deciding_sets");
+__PACKAGE__->result_source_instance->is_virtual(1);
+__PACKAGE__->result_source_instance->view_definition(
+  "SELECT COUNT(*) AS number_of_sets, player_id, player_url_key, player_first_name, player_surname, player_display_name, season_id, season_url_key, season_name, season_start_date, season_end_date, season_complete, result, min_legs, max_legs
+FROM ((
+	SELECT
+		g.home_player AS player_id,
+		p.url_key AS player_url_key,
+		ps.first_name AS player_first_name,
+		ps.surname AS player_surname,
+		ps.display_name AS player_display_name,
+		s.id AS season_id,
+		s.url_key AS season_url_key,
+		s.`name` AS season_name,
+		s.start_date AS season_start_date,
+		s.end_date AS season_end_date,
+		s.complete AS season_complete,
+		g.home_team_legs_won + g.away_team_legs_won AS legs_played,
+		tpl.legs_per_game AS max_legs,
+		tpl.game_type AS game_type,
+		CEILING(tpl.legs_per_game / 2) AS 'min_legs',
+		CASE g.winner
+			WHEN g.home_team THEN 'win'
+			WHEN g.away_team THEN 'loss'
+			ELSE 'unknown'
+		END AS 'result'
+	FROM team_match_games g
+	JOIN team_matches m ON g.home_team = m.home_team AND g.away_team = m.away_team AND g.scheduled_date = m.scheduled_date
+	JOIN template_match_individual tpl ON g.individual_match_template = tpl.id AND tpl.game_type = 'best-of'
+	JOIN people p ON g.home_player = p.id
+	JOIN seasons s ON m.season = s.id
+	JOIN person_seasons ps ON p.id = ps.person AND s.id = ps.season AND ps.team_membership_type = 'active'
+	WHERE g.home_team_legs_won + g.away_team_legs_won = tpl.legs_per_game)
+	UNION ALL
+	(
+	SELECT
+		g.away_player AS player_id,
+		p.url_key AS player_url_key,
+		ps.first_name AS player_first_name,
+		ps.surname AS player_surname,
+		ps.display_name AS player_display_name,
+		s.id AS season_id,
+		s.url_key AS season_url_key,
+		s.`name` AS season_name,
+		s.start_date AS season_start_date,
+		s.end_date AS season_end_date,
+		s.complete AS season_complete,
+		g.home_team_legs_won + g.away_team_legs_won AS legs_played,
+		tpl.legs_per_game AS max_legs,
+		tpl.game_type AS game_type,
+		CEILING(tpl.legs_per_game / 2) AS 'min_legs',
+		CASE g.winner
+			WHEN g.away_team THEN 'win'
+			WHEN g.home_team THEN 'loss'
+			ELSE 'unknown'
+		END AS 'result'
+	FROM team_match_games g
+	JOIN team_matches m ON g.home_team = m.home_team AND g.away_team = m.away_team AND g.scheduled_date = m.scheduled_date
+	JOIN template_match_individual tpl ON g.individual_match_template = tpl.id AND tpl.game_type = 'best-of'
+	JOIN people p ON g.away_player = p.id
+	JOIN seasons s ON m.season = s.id
+	JOIN person_seasons ps ON p.id = ps.person AND s.id = ps.season AND ps.team_membership_type = 'active'
+	WHERE g.home_team_legs_won + g.away_team_legs_won = tpl.legs_per_game)) AS games
+WHERE legs_played = max_legs
+AND game_type = 'best-of'
+GROUP BY player_id, season_id, result"
+);
+
+__PACKAGE__->add_columns(
+  "number_of_sets" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_auto_increment => 1,
+    is_nullable => 0,
+  },
+  "player_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "player_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 45
+  },
+  "player_first_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150
+  },
+  "player_surname" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150
+  },
+  "player_display_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 301
+  },
+  "season_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_auto_increment => 1,
+    is_nullable => 0,
+  },
+  "season_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 30,
+  },
+  "season_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150,
+  },
+  "season_start_date" => {
+    data_type => "date",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 0
+  },
+  "season_end_date" => {
+    data_type => "date",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 0
+  },
+  "season_complete" => {
+    data_type => "tinyint",
+    default_value => 0,
+    is_nullable => 0
+  },
+  "result" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 10,
+  },
+  "min_legs" => {
+    data_type => "smallint",
+    default_value => 0,
+    is_nullable => 0
+  },
+  "max_legs" => {
+    data_type => "smallint",
+    default_value => 0,
+    is_nullable => 0
+  },
+);
+
+__PACKAGE__->set_primary_key("player_id", "season_id");
+
+
+1;

--- a/lib/TopTable/Schema/Result/VwMatchLegDeuceCount.pm
+++ b/lib/TopTable/Schema/Result/VwMatchLegDeuceCount.pm
@@ -1,0 +1,157 @@
+package TopTable::Schema::Result::VwMatchLegDeuceCount;
+
+=head1 NAME
+
+TopTable::Schema::Result::VwMatchLegDeuceCount - a view to group together the deuce leg wins and losses by person / season.
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=item * L<DBIx::Class::PassphraseColumn>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
+
+=head1 VIEW: C<vw_match_leg_deuces>
+
+=cut
+
+__PACKAGE__->table_class('DBIx::Class::ResultSource::View');
+
+__PACKAGE__->table("vw_match_leg_deuces");
+__PACKAGE__->result_source_instance->is_virtual(1);
+__PACKAGE__->result_source_instance->view_definition(
+  "SELECT COUNT(*) AS number_of_deuce_wins, player_id, player_url_key, player_first_name, player_surname, player_display_name, season_id, season_url_key, season_name, season_start_date, season_end_date, season_complete
+FROM ((
+	SELECT
+		g.home_player AS player_id,
+		p.url_key AS player_url_key,
+		ps.first_name AS player_first_name,
+		ps.surname AS player_surname,
+		ps.display_name AS player_display_name,
+		s.id AS season_id,
+		s.url_key AS season_url_key,
+		s.`name` AS season_name,
+		s.start_date AS season_start_date,
+		s.end_date AS season_end_date,
+		s.complete AS season_complete
+	FROM team_match_legs l
+	JOIN team_match_games g ON l.home_team = g.home_team AND l.away_team = g.away_team AND l.scheduled_date = g.scheduled_date AND l.scheduled_game_number = g.scheduled_game_number
+	JOIN team_matches m ON g.home_team = m.home_team AND g.away_team = m.away_team AND g.scheduled_date = m.scheduled_date
+	JOIN template_match_individual tpl ON g.individual_match_template = tpl.id
+	JOIN people p ON g.home_player = p.id
+	JOIN seasons s ON m.season = s.id
+	JOIN person_seasons ps ON p.id = ps.person AND s.id = ps.season AND ps.team_membership_type = 'active'
+	WHERE l.home_team_points_won > tpl.minimum_points_win AND l.home_team_points_won > l.away_team_points_won)
+	UNION ALL
+	(
+	SELECT
+		g.away_player AS player_id,
+		p.url_key AS player_url_key,
+		ps.first_name AS player_first_name,
+		ps.surname AS player_surname,
+		ps.display_name AS player_display_name,
+		s.id AS season_id,
+		s.url_key AS season_url_key,
+		s.`name` AS season_name,
+		s.start_date AS season_start_date,
+		s.end_date AS season_end_date,
+		s.complete AS season_complete
+	FROM team_match_legs l
+	JOIN team_match_games g ON l.home_team = g.home_team AND l.away_team = g.away_team AND l.scheduled_date = g.scheduled_date AND l.scheduled_game_number = g.scheduled_game_number
+	JOIN team_matches m ON g.home_team = m.home_team AND g.away_team = m.away_team AND g.scheduled_date = m.scheduled_date
+	JOIN template_match_individual tpl ON g.individual_match_template = tpl.id
+	JOIN people p ON g.away_player = p.id
+	JOIN seasons s ON m.season = s.id
+	JOIN person_seasons ps ON p.id = ps.person AND s.id = ps.season AND ps.team_membership_type = 'active'
+	WHERE l.away_team_points_won > tpl.minimum_points_win AND l.away_team_points_won > l.home_team_points_won)) AS legs
+GROUP BY player_id, season_id"
+);
+
+__PACKAGE__->add_columns(
+  "number_of_deuce_wins" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_auto_increment => 1,
+    is_nullable => 0,
+  },
+  "player_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 0,
+  },
+  "player_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 45
+  },
+  "player_first_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150
+  },
+  "player_surname" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150
+  },
+  "player_display_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 301
+  },
+  "season_id" => {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_auto_increment => 1,
+    is_nullable => 0,
+  },
+  "season_url_key" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 30,
+  },
+  "season_name" => {
+    data_type => "varchar",
+    is_nullable => 0,
+    size => 150,
+  },
+  "season_start_date" => {
+    data_type => "date",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 0
+  },
+  "season_end_date" => {
+    data_type => "date",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 0
+  },
+  "season_complete" => {
+    data_type => "tinyint",
+    default_value => 0,
+    is_nullable => 0
+  },
+);
+
+__PACKAGE__->set_primary_key("player_id", "season_id");
+
+
+1;

--- a/lib/TopTable/Schema/Result/VwSearchAll.pm
+++ b/lib/TopTable/Schema/Result/VwSearchAll.pm
@@ -1,8 +1,8 @@
-package TopTable::Schema::Result::SearchAllView;
+package TopTable::Schema::Result::VwSearchAll;
 
 =head1 NAME
 
-TopTable::Schema::Result::SearchAllView
+TopTable::Schema::Result::VwSearchAll - A unionised view to get all searchable objects together for searching.
 
 =cut
 
@@ -30,13 +30,13 @@ extends 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
 
-=head1 VIEW: C<club_teams>
+=head1 VIEW: C<vw_search_all>
 
 =cut
 
 __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
 
-__PACKAGE__->table("search_all");
+__PACKAGE__->table("vw_search_all");
 __PACKAGE__->result_source_instance->is_virtual(1);
 __PACKAGE__->result_source_instance->view_definition(
   "-- People

--- a/lib/TopTable/Schema/Result/VwTeamMatch.pm
+++ b/lib/TopTable/Schema/Result/VwTeamMatch.pm
@@ -1,8 +1,8 @@
-package TopTable::Schema::Result::TeamMatchView;
+package TopTable::Schema::Result::VwTeamMatch;
 
 =head1 NAME
 
-TopTable::Schema::Result::TeamMatchView
+TopTable::Schema::Result::VwTeamMatch - a view to get all team matches joined with the necessary data for searching.
 
 =cut
 
@@ -30,13 +30,13 @@ extends 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
 
-=head1 VIEW: C<team_match_view>
+=head1 VIEW: C<vw_team_match>
 
 =cut
 
 __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
 
-__PACKAGE__->table("team_match_view");
+__PACKAGE__->table("vw_team_match");
 __PACKAGE__->result_source_instance->is_virtual(1);
 __PACKAGE__->result_source_instance->view_definition(
   "SELECT m.home_team, m.away_team, m.scheduled_date, m.played_date, hc.url_key AS 'home_club_url_key', ht.url_key AS 'home_team_url_key', ac.url_key AS 'away_club_url_key', at.url_key AS 'away_team_url_key', CONCAT(hc.short_name, ' ', ht.name) AS 'home_team_name', CONCAT(ac.short_name, ' ', at.name) AS 'away_team_name', CONCAT(hc.short_name, ' ', ht.name, ' v ', ac.short_name, ' ', at.name) AS 'match_name', s.id AS 'season_id', s.name AS 'season_name', d.name AS 'division_name', v.name AS 'venue_name', m.home_team_match_score AS 'home_score', m.away_team_match_score AS 'away_score', m.complete, m.cancelled

--- a/lib/TopTable/Schema/Result/VwTeamMatchCounts.pm
+++ b/lib/TopTable/Schema/Result/VwTeamMatchCounts.pm
@@ -1,8 +1,8 @@
-package TopTable::Schema::Result::TeamMatchCountsView;
+package TopTable::Schema::Result::VwTeamMatchCounts;
 
 =head1 NAME
 
-TopTable::Schema::Result::TeamMatchCountsView
+TopTable::Schema::Result::VwTeamMatchCounts - a view to get match counts for teams.
 
 =cut
 
@@ -30,13 +30,13 @@ extends 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
 
-=head1 VIEW: C<club_teams>
+=head1 VIEW: C<vw_team_match_count>
 
 =cut
 
 __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
 
-__PACKAGE__->table("team_match_count");
+__PACKAGE__->table("vw_team_match_count");
 __PACKAGE__->result_source_instance->is_virtual(1);
 __PACKAGE__->result_source_instance->view_definition(
   "SELECT COUNT(*) AS 'number_of_matches', team_id, club_url, team_url, club_full_name, club_short_name, team_name, season_id, season_url, season_name

--- a/lib/TopTable/Schema/Result/VwTeamMatchWeeks.pm
+++ b/lib/TopTable/Schema/Result/VwTeamMatchWeeks.pm
@@ -1,8 +1,8 @@
-package TopTable::Schema::Result::TeamMatchWeeksView;
+package TopTable::Schema::Result::VwTeamMatchWeeks;
 
 =head1 NAME
 
-TopTable::Schema::Result::TeamMatchCountsView
+TopTable::Schema::Result::VwTeamMatchCounts - a view to get team matches played in particular weeks
 
 =cut
 
@@ -30,13 +30,13 @@ extends 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp", "PassphraseColumn");
 
-=head1 VIEW: C<club_teams>
+=head1 VIEW: C<vw_team_match_weeks>
 
 =cut
 
 __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
 
-__PACKAGE__->table("team_match_weeks");
+__PACKAGE__->table("vw_team_match_weeks");
 __PACKAGE__->result_source_instance->is_virtual(1);
 __PACKAGE__->result_source_instance->view_definition(
   "SELECT DATE_ADD(played_date, INTERVAL(-WEEKDAY(played_date)) DAY) AS played_week, COUNT(played_date) AS 'number_of_matches', s.id AS season_id, s.url_key AS season_url, s.`name` AS season_name

--- a/lib/TopTable/Schema/ResultSet/VwClubTeam.pm
+++ b/lib/TopTable/Schema/ResultSet/VwClubTeam.pm
@@ -1,4 +1,4 @@
-package TopTable::Schema::ResultSet::ClubTeamView;
+package TopTable::Schema::ResultSet::VwClubTeam;
 
 use strict;
 use warnings;

--- a/lib/TopTable/Schema/ResultSet/VwHighestPointsWin.pm
+++ b/lib/TopTable/Schema/ResultSet/VwHighestPointsWin.pm
@@ -1,0 +1,49 @@
+package TopTable::Schema::ResultSet::VwHighestPointsWin;
+
+use strict;
+use warnings;
+use base qw( TopTable::Schema::ResultSet );
+
+
+=head2 search_by_name
+
+Return search results based on a supplied full or partial club / team name.
+
+=cut
+
+sub search_by_season {
+  my $class = shift;
+  my ( $season, $comp, $params ) = @_;
+  my $top_only = $params->{top_only} // 0; # Get the top people only - this could be more than one, we need to get the number of people on the top number of sets.
+  
+  my %where = (season_id => $season->id);
+  
+  if ( defined($comp) ) {
+    if ( $comp->isa("TopTable::Schema::Result::Tournament") ) {
+      $where{tourn_id} = $comp->id;
+    } elsif ( $comp->isa("TopTable::Schema::Result::Division") ) {
+      $where{division_id} = $comp->id;
+    } else {
+      # Default to league (division_id isn't null)
+      $where{division_id} = {"!=" => undef};
+    }
+  } else {
+    # Default to league (division_id isn't null)
+    $where{division_id} = {"!=" => undef};
+  }
+  
+  if ( $top_only ) {
+    my $top_number = $class->search(\%where)->get_column("winning_points")->max;
+    $where{winning_points} = $top_number;
+  }
+  
+  return $class->search(\%where, {
+    order_by => [{
+      -desc => [qw( winning_points )],
+    }, {
+      -asc => [qw( player_surname player_first_name opponent_surname opponent_first_name )],
+    }],
+  });
+}
+
+1;

--- a/lib/TopTable/Schema/ResultSet/VwMatchDecidingGame.pm
+++ b/lib/TopTable/Schema/ResultSet/VwMatchDecidingGame.pm
@@ -1,0 +1,36 @@
+package TopTable::Schema::ResultSet::VwMatchDecidingGame;
+
+use strict;
+use warnings;
+use base qw( TopTable::Schema::ResultSet );
+
+
+=head2 search_by_name
+
+Return search results based on a supplied full or partial club / team name.
+
+=cut
+
+sub search_by_season {
+  my $class = shift;
+  my ( $season, $params ) = @_;
+  my $result = $params->{result};
+  my $top_only = $params->{top_only} // 0; # Get the top people only - this could be more than one, we need to get the number of people on the top number of sets.
+  
+  my %where = (season_id => $season->id);
+  $where{result} = $result if defined $result;
+  if ( $top_only ) {
+    my $top_number = $class->search(\%where)->get_column("number_of_sets")->max;
+    $where{number_of_sets} = $top_number;
+  }
+  
+  return $class->search(\%where, {
+    order_by => [{
+      -desc => [qw( number_of_sets )],
+    }, {
+      -asc => [qw( player_surname player_first_name )],
+    }],
+  });
+}
+
+1;

--- a/lib/TopTable/Schema/ResultSet/VwMatchLegDeuceCount.pm
+++ b/lib/TopTable/Schema/ResultSet/VwMatchLegDeuceCount.pm
@@ -1,0 +1,34 @@
+package TopTable::Schema::ResultSet::VwMatchLegDeuceCount;
+
+use strict;
+use warnings;
+use base qw( TopTable::Schema::ResultSet );
+
+
+=head2 search_by_name
+
+Return search results based on a supplied full or partial club / team name.
+
+=cut
+
+sub search_by_season {
+  my $class = shift;
+  my ( $season, $params ) = @_;
+  my $top_only = $params->{top_only} // 0; # Get the top people only - this could be more than one, we need to get the number of people on the top number of sets.
+  
+  my %where = (season_id => $season->id);
+  if ( $top_only ) {
+    my $top_number = $class->search(\%where)->get_column("number_of_deuce_wins")->max;
+    $where{number_of_deuce_wins} = $top_number;
+  }
+  
+  return $class->search(\%where, {
+    order_by => [{
+      -desc => [qw( number_of_deuce_wins )],
+    }, {
+      -asc => [qw( player_surname player_first_name )],
+    }],
+  });
+}
+
+1;

--- a/lib/TopTable/Schema/ResultSet/VwSearchAll.pm
+++ b/lib/TopTable/Schema/ResultSet/VwSearchAll.pm
@@ -1,4 +1,4 @@
-package TopTable::Schema::ResultSet::SearchAllView;
+package TopTable::Schema::ResultSet::VwSearchAll;
 
 use strict;
 use warnings;

--- a/lib/TopTable/Schema/ResultSet/VwTeamMatch.pm
+++ b/lib/TopTable/Schema/ResultSet/VwTeamMatch.pm
@@ -1,4 +1,4 @@
-package TopTable::Schema::ResultSet::TeamMatchView;
+package TopTable::Schema::ResultSet::VwTeamMatch;
 
 use strict;
 use warnings;

--- a/lib/TopTable/Schema/ResultSet/VwTeamMatchCounts.pm
+++ b/lib/TopTable/Schema/ResultSet/VwTeamMatchCounts.pm
@@ -1,4 +1,4 @@
-package TopTable::Schema::ResultSet::TeamMatchWeeksView;
+package TopTable::Schema::ResultSet::VwTeamMatchCounts;
 
 use strict;
 use warnings;
@@ -15,7 +15,7 @@ sub search_by_season {
   my $class = shift;
   my ( $season ) = @_;
   return $class->search({season_id => $season->id}, {
-    order_by => [qw( played_week )]
+    order_by => [qw( club_full_name team_name )]
   });
 }
 

--- a/lib/TopTable/Schema/ResultSet/VwTeamMatchWeeks.pm
+++ b/lib/TopTable/Schema/ResultSet/VwTeamMatchWeeks.pm
@@ -1,4 +1,4 @@
-package TopTable::Schema::ResultSet::TeamMatchCountsView;
+package TopTable::Schema::ResultSet::VwTeamMatchWeeks;
 
 use strict;
 use warnings;
@@ -15,7 +15,7 @@ sub search_by_season {
   my $class = shift;
   my ( $season ) = @_;
   return $class->search({season_id => $season->id}, {
-    order_by => [qw( club_full_name team_name )]
+    order_by => [qw( played_week )]
   });
 }
 

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -481,6 +481,27 @@ msgstr "Use the menu above to view clubs, teams, players and statistics for the 
 msgid "home-page.updates.recent"
 msgstr "Recent updates"
 
+msgid "season.stats.heading"
+msgstr "Season stats"
+
+msgid "season.stats.most-deciding-leg-wins"
+msgstr "Most deciding game wins"
+
+msgid "season.stats.no-deciding-leg-wins"
+msgstr "No one has played a set that&#39;s gone to a deciding game yet."
+
+msgid "season.stats.most-deuce-wins"
+msgstr "Most deuce wins"
+
+msgid "season.stats.no-deuce-wins"
+msgstr "No one has played a deuce game yet."
+
+msgid "season.stats.highest-points-wins"
+msgstr "Highest points win"
+
+msgid "season.stats.highest-points-wins.beat"
+msgstr "beat"
+
 msgid "home-page.updates.view-more"
 msgstr "View more updates"
 

--- a/root/static/css/main-print.css
+++ b/root/static/css/main-print.css
@@ -1090,6 +1090,35 @@ a.winner {font-weight: bold;}
 /* System roles */
 .system {font-weight: bold;}
 
+/*
+  Stats boxes on front page
+*/
+/* container */
+.stats-columns {
+  display:flex;
+  flex-wrap:wrap;
+}
+
+/* columns */
+.stats-columns > div {
+  width:29%;
+  padding:1rem;
+  margin: 1rem;
+  background: #e9e9e9;
+}
+
+div.stats-heading {
+  font-size: 1.5em;
+  font-weight: bold;
+  text-align: center;
+}
+
+div.stats-data {
+  font-size: 1.2em;
+  text-align: center;
+  font-style: italic;
+}
+
 /* Start by setting display:none to make this hidden.
    Then we position it in relation to the viewport window
    with position:fixed. Width, height, top and left speak

--- a/root/static/css/main.css
+++ b/root/static/css/main.css
@@ -1111,6 +1111,35 @@ a.winner {font-weight: bold;}
 /* System roles */
 .system {font-weight: bold;}
 
+/*
+  Stats boxes on front page
+*/
+/* container */
+.stats-columns {
+  display:flex;
+  flex-wrap:wrap;
+}
+
+/* columns */
+.stats-columns > div {
+  width:29%;
+  padding:1rem;
+  margin: 1rem;
+  background: #e9e9e9;
+}
+
+div.stats-heading {
+  font-size: 1.5em;
+  font-weight: bold;
+  text-align: center;
+}
+
+div.stats-data {
+  font-size: 1.2em;
+  text-align: center;
+  font-style: italic;
+}
+
 /* Start by setting display:none to make this hidden.
    Then we position it in relation to the viewport window
    with position:fixed. Width, height, top and left speak
@@ -1166,6 +1195,11 @@ html[xmlns] .clearfix, html[xmlns] .clear-fix {display: block;}
   #index-matches-today, #season-fixtures-results {
     float: none;
     padding-bottom: 20px;
+  }
+
+  /* tablet breakpoint */
+  .stats-columns > div {
+    width:100%;
   }
   
   /* Hide label placeholders so we don't get an odd gap between one field and another in say a collection of address fields */

--- a/root/templates/html/index.ttkt
+++ b/root/templates/html/index.ttkt
@@ -1,14 +1,23 @@
 <div class="index-text">
 [% index_text.page_text OR c.maketext("home-page.default-index-text") %]<br /><br />
 </div>
+[%
+IF current_season;
+  # Show the home page stats for this season
+  INCLUDE "html/seasons/stats.ttkt";
+END;
+-%]
 
 <h4>[% c.maketext("home-page.updates.recent") %]</h4>
+<div id="updates">
 [%
 # Recent updates
 SET table_width = 70;
 INCLUDE "html/event-viewer/view-preloaded.ttkt";
 -%]<br />
-<a href="[% c.uri_for("/event-viewer") %]">[% c.maketext("home-page.updates.view-more") %]</a><br /><br />
+<a href="[% c.uri_for("/event-viewer") %]">[% c.maketext("home-page.updates.view-more") %]</a>
+</div><!-- #updates -->
+
 [%
 # If there are matches to show, display as two columns
 IF matches_to_show;

--- a/root/templates/html/seasons/stats.ttkt
+++ b/root/templates/html/seasons/stats.ttkt
@@ -1,0 +1,98 @@
+<h4>[% c.maketext("season.stats.heading") %]</h4>
+<div class="stats-columns">
+  <div id="most-decider-wins" class="stats-column">
+    <h5>[% c.maketext("season.stats.most-deciding-leg-wins") %]</h5>
+[%
+  IF deciding_game_winners.size;
+    SET people = 0;
+    FOREACH person = deciding_game_winners;
+      people = people + 1;
+      IF people == 1;
+        # First person, display the number (the number is the same for all people)
+%]
+      <div class="stats-heading">[% person.number_of_sets %]</div>
+[%
+      END;
+      
+      IF specific_season;
+        SET uri = c.uri_for_action("/people/view_specific_season", [person.player_url_key, season.url_key]);
+      ELSE;
+        SET uri = c.uri_for_action("/people/view_current_season", [person.player_url_key]);
+      END;
+%]
+      <div class="stats-data"><a href="[% uri %]">[% person.player_display_name | html_entity %]</a></div>
+[%
+    END;
+  ELSE;
+%]
+    <p>[% c.maketext("season.stats.no-deciding-leg-wins") %]</p>
+[%
+  END;
+%]
+  </div>
+  <div id="most-deuce-wins" class="stats-column">
+    <h5>[% c.maketext("season.stats.most-deuce-wins") %]</h5>
+[%
+  IF deuce_game_winners.size;
+    SET people = 0;
+    FOREACH person = deuce_game_winners;
+      people = people + 1;
+      IF people == 1;
+        # First person, display the number (the number is the same for all people)
+%]
+      <div class="stats-heading">[% person.number_of_deuce_wins %]</div>
+[%
+      END;
+      
+      IF specific_season;
+        SET uri = c.uri_for_action("/people/view_specific_season", [person.player_url_key, season.url_key]);
+      ELSE;
+        SET uri = c.uri_for_action("/people/view_current_season", [person.player_url_key]);
+      END;
+%]
+      <div class="stats-data"><a href="[% uri %]">[% person.player_display_name | html_entity %]</a></div>
+[%
+    END;
+  ELSE;
+%]
+    <p>[% c.maketext("season.stats.no-deuce-wins") %]</p>
+[%
+  END;
+%]
+  </div>
+  <div>
+    <h5>[% c.maketext("season.stats.highest-points-wins") %]</h5>
+[%
+  IF highest_point_winners.size;
+    SET people = 0;
+    FOREACH person = highest_point_winners;
+      people = people + 1;
+      IF people == 1;
+        # First person, display the number (the number is the same for all people)
+%]
+      <div class="stats-heading">[% person.winning_points %]-[% person.losing_points %]</div>
+[%
+      END;
+      
+      IF specific_season;
+        SET person_uri = c.uri_for_action("/people/view_specific_season", [person.player_url_key, season.url_key]);
+        SET opponent_uri = c.uri_for_action("/people/view_specific_season", [person.opponent_url_key, season.url_key]);
+      ELSE;
+        SET person_uri = c.uri_for_action("/people/view_current_season", [person.player_url_key]);
+        SET opponent_uri = c.uri_for_action("/people/view_current_season", [person.opponent_url_key]);
+      END;
+      
+      # Get the match so we can link to it
+      SET match = c.model("DB::TeamMatch").get_match_by_ids(person.home_team_id, person.away_team_id, person.scheduled_date);
+%]
+      <div class="stats-data"><a href="[% person_uri %]">[% person.player_display_name | html_entity %]</a> [% c.maketext("season.stats.highest-points-wins.beat") %] <a href="[% opponent_uri %]">[% person.opponent_display_name | html_entity %]</a>: <a href="[% c.uri_for_action("/matches/team/view_by_url_keys", match.url_keys) %]">[% match.name_with_competition %]</a></div>
+[%
+    END;
+  ELSE;
+%]
+    <p>[% c.maketext("season.stats.no-deuce-wins") %]</p>
+[%
+  END;
+%]
+  </div>
+</div>

--- a/root/templates/html/seasons/view.ttkt
+++ b/root/templates/html/seasons/view.ttkt
@@ -1,3 +1,6 @@
+[%
+INCLUDE "html/seasons/stats.ttkt" specific_season = 1;
+%]
 <div class="row">
   <div class="column left">
     <h4>[% c.maketext("seasons.statistics") %]</h4>

--- a/root/templates/html/wrappers/responsive.ttkt
+++ b/root/templates/html/wrappers/responsive.ttkt
@@ -84,8 +84,8 @@ END;
 
 <title>[% page_title %]</title>
 
-<link rel="stylesheet" href="[% c.uri_for('/static/css/main.css') %]?v20" type="text/css" media="screen" />
-<link rel="stylesheet" href="[% c.uri_for('/static/css/main-print.css') %]?v20" type="text/css" media="print" />
+<link rel="stylesheet" href="[% c.uri_for('/static/css/main.css') %]?v21" type="text/css" media="screen" />
+<link rel="stylesheet" href="[% c.uri_for('/static/css/main-print.css') %]?v21" type="text/css" media="print" />
 <link rel="stylesheet" href="[% c.uri_for('/static/css/jqueryui/jquery-ui.min.css') %]" type="text/css" media="screen" />
 <link rel="stylesheet" href="[% c.uri_for('/static/css/jqueryui/jquery-ui.structure.min.css') %]" type="text/css" media="screen" />
 <link rel="stylesheet" href="[% c.uri_for('/static/css/jqueryui/jquery-ui.theme.min.css') %]" type="text/css" media="screen" />
@@ -151,8 +151,8 @@ IF !no_menu;
   <li><a href="[% c.uri_for("/") %]" title="[% c.maketext("menu.title.home") %]">[% c.maketext("menu.text.home") %]</a></li>
   <li><a href="[% c.uri_for("/news") %]" title="[% c.maketext("menu.title.news") %]">[% c.maketext("menu.text.news") %]</a></li>
 [%
-IF nav_current_season;
-  season_html = nav_current_season.name | html_entity;
+IF current_season;
+  season_html = current_season.name | html_entity;
 %]
   <li class="fixtures">
     <a href="[% c.uri_for_action("/fixtures-results/root_current_season") %]" title="[% c.maketext("menu.title.fixtures-results", season_html) %]">[% c.maketext("menu.text.fixtures-results") %]</a>
@@ -172,7 +172,7 @@ IF nav_current_season;
         <a href="[% c.uri_for("/league-tables") %]" title="[% c.maketext("menu.title.league-tables", season_html) %]">[% c.maketext("menu.text.league-tables") %]</a>
         <ul>
 [%
-  FOREACH division_season = nav_current_season.division_seasons;
+  FOREACH division_season = current_season.division_seasons;
     division_html = division_season.name | html_entity;
 -%]
           <li><a href="[% c.uri_for_action("/league-tables/view_current_season", [division_season.division.url_key]) %]" title="[% c.maketext("menu.title.league-tables-division",division_html, season_html) %]">[% division_html %]</a></li>
@@ -188,7 +188,7 @@ IF nav_current_season;
             <a href="[% c.uri_for_action("/league-averages/list_first_page", ["singles"]) %]" title="[% c.maketext("menu.title.league-averages-singles", season_html) %]">[% c.maketext("menu.text.league-averages-singles") %]</a>
             <ul>
 [%
-  FOREACH division_season = nav_current_season.division_seasons;
+  FOREACH division_season = current_season.division_seasons;
     division_html = division_season.name | html_entity;
 -%]
               <li><a href="[% c.uri_for_action("/league-averages/view_current_season", ["singles", division_season.division.url_key]) %]" title="[% c.maketext("menu.title.league-averages-singles-division", division_html, season_html) %]">[% division_html %]</a></li>
@@ -201,7 +201,7 @@ IF nav_current_season;
             <a href="[% c.uri_for_action("/league-averages/list_first_page", ["doubles-individuals"]) %]" title="[% c.maketext("menu.title.league-averages-doubles-individuals", season_html) %]">[% c.maketext("menu.text.league-averages-doubles-individuals") %]</a>
             <ul>
 [%
-  FOREACH division_season = nav_current_season.division_seasons;
+  FOREACH division_season = current_season.division_seasons;
     division_html = division_season.name | html_entity;
 -%]
               <li><a href="[% c.uri_for_action("/league-averages/view_current_season", ["doubles-individuals", division_season.division.url_key]) %]" title="[% c.maketext("menu.title.league-averages-doubles-individuals-division", division_html, season_html) %]">[% division_html %]</a></li>
@@ -211,10 +211,10 @@ IF nav_current_season;
             </ul>
           </li>
           <li>
-            <a href="[% c.uri_for_action("/league-averages/list_first_page", ["doubles-pairs"]) %]" title="[% c.maketext("menu.title.league-averages-doubles-pairs", nav_current_season.name) %]">[% c.maketext("menu.text.league-averages-doubles-pairs") %]</a>
+            <a href="[% c.uri_for_action("/league-averages/list_first_page", ["doubles-pairs"]) %]" title="[% c.maketext("menu.title.league-averages-doubles-pairs", current_season.name) %]">[% c.maketext("menu.text.league-averages-doubles-pairs") %]</a>
             <ul>
 [%
-  FOREACH division_season = nav_current_season.division_seasons;
+  FOREACH division_season = current_season.division_seasons;
     division_html = division_season.name | html_entity;
 -%]
               <li><a href="[% c.uri_for_action("/league-averages/view_current_season", ["doubles-pairs", division_season.division.url_key]) %]" title="[% c.maketext("menu.title.league-averages-doubles-pairs-division", division_html, season_html) %]">[% division_html %]</a></li>
@@ -227,7 +227,7 @@ IF nav_current_season;
             <a href="[% c.uri_for_action("/league-averages/list_first_page", ["doubles-teams"]) %]" title="[% c.maketext("menu.title.league-averages-doubles-teams", season_html) %]">[% c.maketext("menu.text.league-averages-doubles-teams") %]</a>
             <ul>
 [%
-  FOREACH division_season = nav_current_season.division_seasons;
+  FOREACH division_season = current_season.division_seasons;
     division_html = division_season.name | html_entity;
 -%]
               <li><a href="[% c.uri_for_action("/league-averages/view_current_season", ["doubles-teams", division_season.division.url_key]) %]" title="[% c.maketext("menu.title.league-averages-doubles-teams-division", division_html, season_html) %]">[% division_html %]</a></li>
@@ -362,7 +362,7 @@ END;
     <ul>
       <li><a href="[% c.uri_for("/info/officials") %]" title="[% c.maketext("menu.title.officials", season_html) %]">[% c.maketext("menu.text.officials") %]</a></li>
 [%
-IF nav_current_season;
+IF current_season;
   # Show team captains on the menu if there's a current season
 -%]
       <li>
@@ -528,7 +528,7 @@ END;
 [%    
     END;
     
-    IF authorisation.season_create AND !nav_current_season;
+    IF authorisation.season_create AND !current_season;
 -%]
       <li><a href="[% c.uri_for("/seasons/create") %]" title="[% c.maketext("seasons.create") %]"><img src="[% c.uri_for("/static/images/icons/0009-Add-icon-16.png") %]" /> &laquo; [% c.maketext("admin.create") %] &raquo;</a></li>
 [%


### PR DESCRIPTION
- **[New]** New views to show three specific stats: most wins in a deciding game; most deuce wins; and highest points win.
- **[New]** Stats template file to be included where stats are to appear; currently this is on the home page (for the current season, where there is a current season) and the season page for each season.
- **[New]** Moved nav_current_season lookup (for the nav bar) from the Root end sub to the begin sub in the same controller; renamed the stashed item to current_season.  Removed all other lookups to $c->model("DB::Season")->current_season, as they are now using the stashed value.
- **[New]** Renamed all existing and new views to start with "Vw" (previously they ended "View").