### PR TITLE
League table model cleanup

### DIFF
--- a/lib/TopTable/Controller/Events.pm
+++ b/lib/TopTable/Controller/Events.pm
@@ -2239,7 +2239,7 @@ sub group_view :Private {
     view_online_display => sprintf("Viewing %s", $enc_event_name),
     view_online_link => 1,
     entrants => [$group->get_entrants_in_table_order],
-    last_updated => $group->get_tables_last_updated_timestamp,
+    last_updated => $group->table_last_updated,
     ranking_template => $ranking_template,
     match_template => $match_template,
     matches => $matches,

--- a/lib/TopTable/Controller/LeagueAverages.pm
+++ b/lib/TopTable/Controller/LeagueAverages.pm
@@ -374,7 +374,7 @@ sub view_finalise :Private {
     
     $c->stash({
       singles_averages => $singles_averages,
-        singles_last_updated => $c->model("DB::PersonSeason")->get_tables_last_updated_timestamp({
+      singles_last_updated => $c->model("DB::PersonSeason")->get_tables_last_updated_timestamp({
         season => $season,
         division => $division,
       }),

--- a/lib/TopTable/Controller/LeagueTables.pm
+++ b/lib/TopTable/Controller/LeagueTables.pm
@@ -318,14 +318,8 @@ sub view_finalise :Private {
     divisions => [$season->divisions],
     view_online_display => sprintf("Viewing %s table for %s", $division->name, $season->name),
     view_online_link => 1,
-    entrants => [$c->model("DB::TeamSeason")->get_teams_in_division_in_league_table_order({
-      season => $season,
-      division => $division,
-    })],
-    last_updated => $c->model("DB::TeamSeason")->get_tables_last_updated_timestamp({
-      season => $season,
-      division => $division,
-    }),
+    entrants => [$division_season->league_table],
+    last_updated => $division_season->table_last_updated,
     table_complete => $division_season->table_complete,
     points_adjustments => $points_adjustments,
     ranking_template => $ranking_template,

--- a/lib/TopTable/Schema/Result/DivisionSeason.pm
+++ b/lib/TopTable/Schema/Result/DivisionSeason.pm
@@ -272,6 +272,48 @@ __PACKAGE__->has_many(
 # Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-03 10:04:05
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:XP6XPWCZnyfGiG3Hu+HsmA
 
+=head2 league_table
+
+Get the teams in this division / season in league table order.
+
+=cut
+
+sub league_table {
+  my $self = shift;
+  
+  return $self->search_related("team_seasons", {}, {
+    prefetch  => ["team", {
+      club_season => "club",
+    }],
+    order_by  => [{
+      -desc => [qw( games_won matches_won matches_drawn )],
+    }, {
+      -asc  => [qw( games_lost matches_lost )],
+    }, {
+      -desc => [qw( legs_won )],
+    }, {
+      -asc => [qw( club_season.short_name me.name )],
+    }],
+  });
+}
+
+=head2 table_last_updated
+
+For a given season and division, return the last updated date / time.
+
+=cut
+
+sub table_last_updated {
+  my $self = shift;
+  
+  my $last_updated_team = $self->find_related("team_seasons", {}, {
+    rows => 1,
+    order_by => {-desc => "last_updated"}
+  });
+  
+  return $last_updated_team->last_updated if defined($last_updated_team);
+}
+
 =head2 points_adjustments
 
 Get a list of all points adjustments for this division/season from the team_seasons relation.

--- a/lib/TopTable/Schema/Result/TeamSeason.pm
+++ b/lib/TopTable/Schema/Result/TeamSeason.pm
@@ -956,10 +956,7 @@ Returns the team's league position within the season.
 sub league_position {
   my $self = shift;
   
-  my $teams_in_division = $self->result_source->schema->resultset("TeamSeason")->get_teams_in_division_in_league_table_order({
-    season => $self->season,
-    division => $self->division_season->division,
-  });
+  my $teams_in_division = $self->division_season->league_table;
   
   my $pos = 0;
   

--- a/lib/TopTable/Schema/Result/TournamentRoundGroup.pm
+++ b/lib/TopTable/Schema/Result/TournamentRoundGroup.pm
@@ -1087,13 +1087,13 @@ sub has_entrant {
   return $self->search_related($member_rel, \%where, \%attrib)->count;
 }
 
-=head2 get_tables_last_updated_timestamp
+=head2 table_last_updated
 
 Return the last updated date / time.
 
 =cut
 
-sub get_tables_last_updated_timestamp {
+sub table_last_updated {
   my $self = shift;
   my $member_rel;
   my $entry_type = $self->entry_type;

--- a/lib/TopTable/Schema/ResultSet/TeamSeason.pm
+++ b/lib/TopTable/Schema/ResultSet/TeamSeason.pm
@@ -5,37 +5,6 @@ use warnings;
 use base qw( TopTable::Schema::ResultSet );
 use DateTime;
 
-=head2 get_teams_in_division_in_league_table_order
-
-Retrieve people in a given season / division in averages order.  If the $criteria hashref is given, these will be added to the query.
-
-=cut
-
-sub get_teams_in_division_in_league_table_order {
-  my $class = shift;
-  my ( $params ) = @_;
-  my $season = delete $params->{season};
-  my $division = delete $params->{division};
-  
-  return $class->search({
-    "me.season" => $season->id,
-    division    => $division->id,
-  }, {
-    prefetch  => ["team", {
-      club_season => "club",
-    }],
-    order_by  => [{
-      -desc => [ qw( games_won matches_won matches_drawn matches_played ) ]
-    }, {
-      -asc  => [ qw( games_lost matches_lost ) ]
-    }, {
-      -desc => [ qw( games_won ) ]
-    }, {
-      -asc  => [ qw( club.short_name team.name ) ]
-    }],
-  });
-}
-
 =head2 get_doubles_teams_in_division_in_averages_order
 
 Retrieve doubles teams in a given season / division in averages order.
@@ -72,29 +41,6 @@ sub get_doubles_teams_in_division_in_averages_order {
       -asc  => [qw( club.short_name team.name )],
     }],
   });
-}
-
-=head2 get_tables_last_updated_timestamp
-
-For a given season and division, return the last updated date / time.
-
-=cut
-
-sub get_tables_last_updated_timestamp {
-  my $class = shift;
-  my ( $params ) = @_;
-  my $division = $params->{division};
-  my $season = $params->{season};
-  
-  my $last_updated_team = $class->find({
-    season => $season->id,
-    division => $division->id,
-  }, {
-    rows => 1,
-    order_by => {-desc => "last_updated"}
-  });
-  
-  return $last_updated_team->last_updated if defined($last_updated_team);
 }
 
 =head2 grid_positions_set


### PR DESCRIPTION
- **[New]** League table ordering adjusted to descendingly games_won, matches_won, matches_drawn; ascendingly games_lost, matches_lost; descendingly legs_won; ascendingly team full name.
- **[New]** League table fetch routine moved to DivisionSeason from TeamSeason and renamed to league_table / table_last_updated.