### PR TITLE
Team venue override

### DIFF
--- a/lib/TopTable/Schema/Result/FixturesGrid.pm
+++ b/lib/TopTable/Schema/Result/FixturesGrid.pm
@@ -1328,7 +1328,7 @@ sub create_matches {
                 division => $is_tournament ? undef : $grid_user_id, # If it's not a tournament, this 
                 tournament_round => $is_tournament ? $tourn_group->tournament_round->id : undef,
                 tournament_group => $is_tournament ? $tourn_group->id: undef,
-                venue => $home_team->club->venue->id,
+                venue => defined($home_team->venue) ? $home_team->venue->id : $home_team->club->venue->id,
                 scheduled_week => $scheduled_week,
                 team_match_template => $match_template->id,
                 fixtures_grid => $self->id,

--- a/lib/TopTable/Schema/Result/Team.pm
+++ b/lib/TopTable/Schema/Result/Team.pm
@@ -68,6 +68,15 @@ __PACKAGE__->table("teams");
   is_foreign_key: 1
   is_nullable: 0
 
+=head2 venue
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_foreign_key: 1
+  is_nullable: 1
+
+If NULL, use the club venue
+
 =head2 default_match_start
 
   data_type: 'time'
@@ -93,6 +102,13 @@ __PACKAGE__->add_columns(
     extra => { unsigned => 1 },
     is_foreign_key => 1,
     is_nullable => 0,
+  },
+  "venue",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_foreign_key => 1,
+    is_nullable => 1,
   },
   "default_match_start",
   { data_type => "time", is_nullable => 1 },
@@ -262,9 +278,29 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 venue
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-09-29 23:47:56
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:izvVcij50MYlkFylPAoMNA
+Type: belongs_to
+
+Related object: L<TopTable::Schema::Result::Venue>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "venue",
+  "TopTable::Schema::Result::Venue",
+  { id => "venue" },
+  {
+    is_deferrable => 1,
+    join_type     => "LEFT",
+    on_delete     => "RESTRICT",
+    on_update     => "RESTRICT",
+  },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2025-08-05 11:57:53
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:6g9NrRW4OmV/jgy6lOZWSw
 
 use HTML::Entities;
 

--- a/lib/TopTable/Schema/Result/TeamSeason.pm
+++ b/lib/TopTable/Schema/Result/TeamSeason.pm
@@ -83,6 +83,15 @@ __PACKAGE__->table("team_seasons");
   is_foreign_key: 1
   is_nullable: 1
 
+=head2 venue
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_foreign_key: 1
+  is_nullable: 1
+
+If NULL, use the club_season venue
+
 =head2 matches_played
 
   data_type: 'tinyint'
@@ -403,6 +412,13 @@ __PACKAGE__->add_columns(
     is_nullable => 0,
   },
   "captain",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_foreign_key => 1,
+    is_nullable => 1,
+  },
+  "venue",
   {
     data_type => "integer",
     extra => { unsigned => 1 },
@@ -905,9 +921,29 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 venue
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2025-02-28 10:30:32
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:vJioYl4OU+/ERVGYZRCZYg
+Type: belongs_to
+
+Related object: L<TopTable::Schema::Result::Venue>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "venue",
+  "TopTable::Schema::Result::Venue",
+  { id => "venue" },
+  {
+    is_deferrable => 1,
+    join_type     => "LEFT",
+    on_delete     => "RESTRICT",
+    on_update     => "RESTRICT",
+  },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2025-08-05 11:57:53
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:YStnxJzSL/37OibT+ZnR9A
 
 __PACKAGE__->add_columns(
     "last_updated",
@@ -1001,6 +1037,17 @@ sub cancelled_matches {
   my $away_matches = $self->search_related("team_matches_away_team_seasons", {cancelled => 1});
   
   return $home_matches->union($away_matches);
+}
+
+=head2 custom_venue
+
+Returns true if the team season has a custom venue set, i.e., not the club season's venue.
+
+=cut
+
+sub custom_venue {
+  my $self = shift;
+  return defined($self->venue) && $self->venue->id != $self->club_season->venue->id;
 }
 
 =head2 points_adjustments

--- a/lib/TopTable/Schema/Result/TournamentRound.pm
+++ b/lib/TopTable/Schema/Result/TournamentRound.pm
@@ -2505,7 +2505,13 @@ sub create_matches {
         if ( defined($self->venue) ) {
           $rounds{$round}{matches}{$match}{venue} = $self->venue;
         } elsif ( defined($home_season) ) {
-          $rounds{$round}{matches}{$match}{venue} = $home_season->club_season->venue;
+          if ( defined($home_season->venue) ) {
+            # Home team has a custom venue, use that
+            $rounds{$round}{matches}{$match}{venue} = $home_season->venue;
+          } else {
+            # Home team has no custom venue, so use the club's default venue
+            $rounds{$round}{matches}{$match}{venue} = $home_season->club_season->venue;
+          }
         }
       }
       

--- a/lib/TopTable/Schema/Result/Venue.pm
+++ b/lib/TopTable/Schema/Result/Venue.pm
@@ -283,6 +283,36 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 team_seasons
+
+Type: has_many
+
+Related object: L<TopTable::Schema::Result::TeamSeason>
+
+=cut
+
+__PACKAGE__->has_many(
+  "team_seasons",
+  "TopTable::Schema::Result::TeamSeason",
+  { "foreign.venue" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 teams
+
+Type: has_many
+
+Related object: L<TopTable::Schema::Result::Team>
+
+=cut
+
+__PACKAGE__->has_many(
+  "teams",
+  "TopTable::Schema::Result::Team",
+  { "foreign.venue" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 tournament_rounds
 
 Type: has_many
@@ -314,8 +344,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-09-29 23:47:56
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:WClnG5gi5QQPhA1xKPzehQ
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2025-08-05 11:57:53
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3TxgkpSVa6uDyq9/feiW/A
 
 use HTML::Entities;
 

--- a/root/locale/en_GB.po
+++ b/root/locale/en_GB.po
@@ -918,6 +918,9 @@ msgstr "Division rank"
 msgid "teams.field.home-night"
 msgstr "Home night"
 
+msgid "teams.field.venue"
+msgstr "Venue"
+
 msgid "teams.field.start-time"
 msgstr "Match start time"
 
@@ -1002,6 +1005,9 @@ msgstr "The club cannot be edited after matches have been created in the current
 msgid "teams.form.notice.cannot-edit-division"
 msgstr "The division cannot be edited after matches have been created in the current season."
 
+msgid "teams.form.notice.cannot-edit-venue"
+msgstr "The venue cannot be edited after matches have been created in the current season."
+
 msgid "teams.form.notice.no-people-captains"
 msgstr "There are no people currently in the database; you will get the option to add people as captains for teams when you create them."
 
@@ -1068,6 +1074,12 @@ msgstr "The home night is invalid."
 msgid "teams.form.error.home-night-blank"
 msgstr "You must specify a home night."
 
+msgid "teams.form.error.venue-inactive"
+msgstr "%1 is not an active venue; please select from the list, or activate %1 before trying to use it."
+
+msgid "teams.form.error.venue-invalid"
+msgstr "The venue specified is not valid."
+
 msgid "teams.form.error.start-hour-invalid"
 msgstr "The default match start hour value is invalid; it must be selected from the list (&#39;00&#39; to &#39;23&#39;).  You may leave this value blank and the team&#39;s home matches will default to the club&#39;s match start time; if this is blank, the season&#39;s default match start time will be used."
 
@@ -1133,6 +1145,9 @@ msgstr "Tournament results"
 
 msgid "teams.message.did-not-enter"
 msgstr "%1 did not enter %2."
+
+msgid "teams.venue.custom-notice"
+msgstr "%1 plays at a different venue to the rest of %2 - please ensure you are travelling to the correct venue."
 
 msgid "teams.fixtures.day"
 msgstr "Day"

--- a/root/templates/html/teams/create-edit.ttkt
+++ b/root/templates/html/teams/create-edit.ttkt
@@ -6,8 +6,10 @@ USE zeroes = format("%02d");
 IF mid_season;
   club_disabled = ' disabled="disabled"';
   division_disabled = ' disabled="disabled"';
+  venue_disabled = ' disabled="disabled"';
   club_tooltip = ' title="' _ c.maketext("teams.form.notice.cannot-edit-club");
   division_tooltip = ' title="' _ c.maketext("teams.form.notice.cannot-edit-division");
+  venue_tooltip = ' title="' _ c.maketext("teams.form.notice.cannot-edit-venue");
 END;
 
 IF c.flash.show_flashed;
@@ -15,6 +17,7 @@ IF c.flash.show_flashed;
   SET club = c.flash.club;
   SET division = c.flash.division;
   SET home_night = c.flash.home_night;
+  SET venue = c.flash.venue;
   SET start_hour = c.flash.start_hour;
   SET start_minute = c.flash.start_minute;
 ELSIF preset_club;
@@ -28,9 +31,11 @@ ELSE;
   IF team_season;
     SET division = team_season.division_season.division;
     SET home_night = team_season.home_night;
+    SET venue = team_season.venue;
   ELSE;
     SET division = last_team_season.division_season.division;
     SET home_night = last_team_season.home_night;
+    SET venue = last_team_season.venue;
   END;
   
   SET time_bits = team.default_match_start.split(":");
@@ -110,6 +115,29 @@ WHILE (night = home_nights.next);
   END;
 -%]
           <option value="[% night.weekday_number %]"[% selected %]>[% c.maketext("weekdays." _ night.weekday_number) %]</option>
+[%
+END;
+-%]
+    </select>
+  </div>
+  <div class="clear-fix"></div>
+</div>
+  
+<div class="label-field-container">
+  <label for="venue">[% c.maketext("teams.field.venue") %]</label>
+  <div class="field-container">
+    <select id="venue" name="venue"[% venue_disabled _ venue_tooltip %] data-placeholder="[% c.maketext("teams.field.venue") %]">
+      <option value=""></option>
+[%
+WHILE (lookup_venue = venues.next);
+  # Set selected text if needed;
+  IF venue.id == lookup_venue.id;
+    SET selected = ' selected="selected"';
+  ELSE;
+    SET selected = '';
+  END;
+-%]
+      <option value="[% lookup_venue.id %]"[% selected %]>[% lookup_venue.name | html_entity %]</option>
 [%
 END;
 -%]

--- a/root/templates/html/teams/view.ttkt
+++ b/root/templates/html/teams/view.ttkt
@@ -78,6 +78,16 @@ IF season;
 -%]
           <td><a href="[% club_uri %]">[% team.club.full_name | html_entity %]</a></td>
           </tr>
+[%
+      IF team_season.custom_venue;
+-%]
+          <tr>
+            <th scope="row">[% c.maketext("teams.field.venue") %]</th>
+            <td><a href="[% c.uri_for_action("/venues/view" [team_season.venue.url_key]) %]">[% team_season.venue.name | html_entity %]</a></td>
+          </tr>
+[%
+      END;
+-%]
           <tr>
             <th scope="row">[% c.maketext("teams.field.home-night") %]</th>
             <td>[% team_season.home_night.weekday_name %]</td>


### PR DESCRIPTION
- **[New]** Teams can now have a venue selected that's different to the rest of the club.  DB update required to add venue fields and foreign keys to teams and team_seasons teables.
- **[New]** Venue displayed on team view page, only if it's got a custom venue set.  There's also an info message at the top to draw attention to this.
- **[New]** Match creation routines (from fixtures grid or tournament round) now use the team's venue if set before using the club's venue (tournament round / group venue settings still override this).