### PR TITLE
League tables - highlight priority order column

### DIFF
--- a/lib/TopTable/Controller/LeagueTables.pm
+++ b/lib/TopTable/Controller/LeagueTables.pm
@@ -282,7 +282,7 @@ sub view_finalise :Private {
   my $table_view_js = "view";
   $table_view_js .= "-points" if $ranking_template->assign_points;
   $table_view_js .= "-hcp" if $match_template->handicapped;
-  $table_view_js = $c->uri_for("/static/script/tables/$table_view_js.js", {v => 3});
+  $table_view_js = $c->uri_for("/static/script/tables/$table_view_js.js", {v => 4});
   
   my @ext_scripts = (
     $c->uri_for("/static/script/plugins/datatables/dataTables.min.js"),

--- a/root/static/css/main-print.css
+++ b/root/static/css/main-print.css
@@ -1063,6 +1063,8 @@ td.game-number, th.game-number {text-align: center;}
 span.game-result {font-weight: bold;}
 span.leg-separator {display: none;}
 td.leg-scores {clear: both;}
+td.rank-priority {font-weight: bold; background-color: #DCDCDC;}
+
 span.leg-score {
   display: inline-block;
   width: 50px;

--- a/root/static/css/main.css
+++ b/root/static/css/main.css
@@ -1084,6 +1084,8 @@ td.game-number, th.game-number {text-align: center;}
 span.game-result {font-weight: bold;}
 span.leg-separator {display: none;}
 td.leg-scores {clear: both;}
+td.rank-priority {font-weight: bold; background-color: #DCDCDC;}
+
 span.leg-score {
   display: inline-block;
   width: 50px;

--- a/root/static/script/tables/view-hcp.js
+++ b/root/static/script/tables/view-hcp.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
       {responsivePriority: 8}, // Won
       {responsivePriority: 10}, // Drawn
       {responsivePriority: 9}, // Lost
-      {responsivePriority: 3}, // For
+      {responsivePriority: 3, className: "rank-priority"}, // For
       {responsivePriority: 4}, // Against
       {responsivePriority: 6}, // Handicap
       {responsivePriority: 5} // Points / games difference

--- a/root/static/script/tables/view-points-hcp.js
+++ b/root/static/script/tables/view-points-hcp.js
@@ -21,7 +21,7 @@ $(document).ready(function() {
       {responsivePriority: 8}, // Against
       {responsivePriority: 5}, // Handicap
       {responsivePriority: 4}, // Points / games difference
-      {responsivePriority: 3} // Points
+      {responsivePriority: 3, className: "rank-priority"} // Points
     ],
   });
 });

--- a/root/static/script/tables/view-points.js
+++ b/root/static/script/tables/view-points.js
@@ -20,7 +20,7 @@ $(document).ready(function() {
       {responsivePriority: 6}, // For
       {responsivePriority: 7}, // Against
       {responsivePriority: 4}, // Points / games difference
-      {responsivePriority: 3} // Points
+      {responsivePriority: 3, className: "rank-priority"} // Points
     ],
   });
 });

--- a/root/static/script/tables/view.js
+++ b/root/static/script/tables/view.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
       {responsivePriority: 7}, // Won
       {responsivePriority: 9}, // Drawn
       {responsivePriority: 8}, // Lost
-      {responsivePriority: 3}, // For
+      {responsivePriority: 3, className: "rank-priority"}, // For
       {responsivePriority: 4}, // Against
       {responsivePriority: 5} // Points / games difference
     ],

--- a/root/templates/html/people/view.ttkt
+++ b/root/templates/html/people/view.ttkt
@@ -295,7 +295,7 @@ IF teams.size;
 -%]
     <ul class="option-list">
       <li>
-        [% c.maketext("people.no-singles-games-played", encoded_first_name) %]
+        [% c.maketext("people.no-singles-games-played", enc_first_name) %]
       </li>
     </ul>
 [%
@@ -455,7 +455,7 @@ IF teams.size;
 -%]
     <ul class="option-list">
       <li>
-        [% c.maketext("people.no-doubles-games-played", encoded_first_name) %]
+        [% c.maketext("people.no-doubles-games-played", enc_first_name) %]
       </li>
     </ul>
 [%
@@ -494,7 +494,7 @@ IF teams.size;
     SET averages_uri = c.uri_for_action("/league-averages/view_current_season", ["singles", team_season.division_season.division.url_key]);
   END;
   
-  team_name = team_season.club_season.full_name | html_entity;
+  team_name = team_season.club_season.short_name _ " " _ team_season.name | html_entity;
   SET team_display = '<a href="' _ team_uri _ '">' _ team_name _ '</a>';
 ELSE;
   SET team_display = c.maketext("people.message.not-registered");
@@ -549,7 +549,7 @@ IF captaincies.count;
       SET captain_team_uri = c.uri_for_action("/teams/view_current_season_by_url_key", [captaincy.club_season.club.url_key, captaincy.team.url_key]);
     END;
     
-    captaincy_team_name = captaincy.club_season.full_name | html_entity;
+    captaincy_team_name = captaincy.club_season.short_name _ " " _ captaincy.name | html_entity;
     IF cpt_printed > 1;
 -%]
               <br />

--- a/root/templates/html/wrappers/responsive.ttkt
+++ b/root/templates/html/wrappers/responsive.ttkt
@@ -84,8 +84,8 @@ END;
 
 <title>[% page_title %]</title>
 
-<link rel="stylesheet" href="[% c.uri_for('/static/css/main.css') %]?v22" type="text/css" media="screen" />
-<link rel="stylesheet" href="[% c.uri_for('/static/css/main-print.css') %]?v22" type="text/css" media="print" />
+<link rel="stylesheet" href="[% c.uri_for('/static/css/main.css') %]?v23" type="text/css" media="screen" />
+<link rel="stylesheet" href="[% c.uri_for('/static/css/main-print.css') %]?v23" type="text/css" media="print" />
 <link rel="stylesheet" href="[% c.uri_for('/static/css/jqueryui/jquery-ui.min.css') %]" type="text/css" media="screen" />
 <link rel="stylesheet" href="[% c.uri_for('/static/css/jqueryui/jquery-ui.structure.min.css') %]" type="text/css" media="screen" />
 <link rel="stylesheet" href="[% c.uri_for('/static/css/jqueryui/jquery-ui.theme.min.css') %]" type="text/css" media="screen" />


### PR DESCRIPTION
- **[New]** Add a rank-priority column to league and group tables for the main ordering column, to make it stand out.  This is the points column for tables with points, or the 'For' column for tables without.
- **[Fix]** Incorrect variable used for first name on people view page where they'd not played any singles / doubles sets, so the text wasn't displaying the name.
- **[Fix]** Person summary showed the club name rather than team name under "registered for" and "captain for".